### PR TITLE
Registry: rewrite dist.tarball urls to match request

### DIFF
--- a/cloud/dev.sh
+++ b/cloud/dev.sh
@@ -24,7 +24,10 @@ fi;
 # right owner (see certs/generate.sh).
 mkdir -p $TR_VAR_DIR/certs
 
-compose build && compose up -d
+# For dev: create a folder read by cloud-app where capabilities can be updated live
+mkdir -p /tmp/caps
+
+compose build && compose up -d $@
 
 if (getent hosts random-subdomain-3245234.$TR_HOST > /dev/null); then
   echo "mDNS verification successful"

--- a/cloud/docker-compose.yaml
+++ b/cloud/docker-compose.yaml
@@ -138,6 +138,7 @@ services:
     networks:
       - default
       - shared
+      - caps
     logging:
       driver: local
 


### PR DESCRIPTION
- docker-compose: add registry to caps-network
- docker.js:
  - no more need for extrahosts for registry,
  - no more need for network=host mode when building,
  - setting logging driver

Fixes transitive#376.