### PR TITLE
registry: hotfix, need to use PROTOCOL in tarball

### DIFF
--- a/cloud/registry/index.js
+++ b/cloud/registry/index.js
@@ -273,7 +273,7 @@ const startServer = ({collections: {tarballs, packages, accounts}}) => {
       package.versions.forEach(version => {
         if (version.dist?.tarball) {
           const {pathname} = new URL(version.dist.tarball);
-          version.dist.tarball = `${req.protocol}://${req.headers.host}${pathname}`;
+          version.dist.tarball = `${PROTOCOL}://${req.headers.host}${pathname}`;
         }
       });
 


### PR DESCRIPTION
Otherwise we rewrite the URL to http:// because the registry gets a http request from the proxy (but the proxy got it via https).