### PR TITLE
robot-agent, use new aptFetch.sh to upgrade nodejs

### DIFF
--- a/robot-agent/aptCommon.sh
+++ b/robot-agent/aptCommon.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# Common functions and definitions used by aptLocal and aptFetch.
+
+set -e
+
+# -------------------------------------------------------------------
+# Colors
+BLACK="\033[30m"
+RED="\033[31m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+BLUE="\033[34m"
+PINK="\033[35m"
+CYAN="\033[36m"
+WHITE="\033[37m"
+NORMAL="\033[0;39m"
+
+
+# -------------------------------------------------------------------
+# Env vars
+DIR=~/.transitive
+BASEDIR=$(dirname $0)
+
+# -------------------------------------------------------------------
+# Functions
+
+printStep() {
+  printf "\n$GREEN$@$NORMAL\n"
+}
+
+getROSRelease() {
+  case $(lsb_release -sc) in
+    xenial) echo kinetic;;
+    bionic) echo melodic;;
+    focal) echo noetic;;
+  esac
+}
+
+# Set up apt sources
+setupSources() {
+
+  printStep "Set apt sources"
+
+  # ROS_RELEASE=$(ls -1 --color=never ~/.transitive/opt/ros | head -n 1)
+  # ^^ would fail if no ros packages were yet installed
+  ROS_RELEASE=$(getROSRelease)
+
+  cp {,$DIR}/etc/apt/sources.list
+  if [[ -z $ROS_RELEASE ]]; then
+    echo "No ROS1 release for $(lsb_release -sc)";
+    # remove it in case an older version of aptLocal added it:
+    rm -rf $DIR/etc/apt/sources.list.d/ros-latest.list
+  else
+  echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > $DIR/etc/apt/sources.list.d/ros-latest.list
+  fi;
+
+  if [[ -e /etc/apt/trusted.gpg ]]; then cp {,$DIR}/etc/apt/trusted.gpg; fi
+  cp /etc/apt/trusted.gpg.d/* $DIR/etc/apt/trusted.gpg.d || true
+  # For now, always get latest ROS repo keys, to mitigate stuff like:
+  # https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669
+
+
+
+  printStep "Import repo keys"
+
+  curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | unshare -rm apt-key --keyring $DIR/etc/apt/trusted.gpg.d/ros.gpg add -
+
+  # node.js:
+  ARCH=$(dpkg --print-architecture)
+  echo "deb [arch=$ARCH signed-by=$DIR/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" > $DIR/etc/apt/sources.list.d/nodesource.list
+  echo "deb [arch=$ARCH signed-by=$DIR/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" >> $DIR/etc/apt/sources.list.d/nodesource.list
+  rm -f $DIR/etc/apt/keyrings/nodesource.gpg
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o $DIR/etc/apt/keyrings/nodesource.gpg
+}
+
+# -------------------------------------------------------------------
+# Main: always done
+
+printStep "Configuring local apt"
+mkdir -p $DIR/var/lib/apt/lists/partial
+mkdir -p $DIR/var/cache/apt/archives/partial
+mkdir -p $DIR/etc/apt/{apt.conf.d,sources.list.d,preferences.d,trusted.gpg.d,keyrings}
+mkdir -p $DIR/var/log/apt
+echo "dir \"$DIR\";" > $DIR/etc/apt/apt.conf
+export APT_CONFIG=$DIR/etc/apt/apt.conf
+

--- a/robot-agent/aptFetch.sh
+++ b/robot-agent/aptFetch.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Script to fetch and unpack a named apt package. Uses the same sources as
+# aptLocal.
+
+set -e
+
+. $(dirname $0)/aptCommon.sh
+
+# -------------------------------------------------------------------------
+
+if [[ $# < 1 ]]; then
+  echo "no package specified";
+  exit 1;
+fi;
+
+setupSources
+
+printStep "Running apt-get update"
+apt-get update || echo "Ignoring apt-get update errors"
+
+
+TMP=$(mktemp -d)
+cd $TMP
+echo "Running in $TMP"
+
+printStep "Fetching package $1"
+apt-get download $1
+
+printStep "Unpacking package"
+dpkg -x *.deb $DIR
+NAME=$(dpkg-deb -f *.deb package)
+echo $NAME
+dpkg-deb -e *.deb $DIR/var/lib/dpkg/status.d/$NAME
+# add status installed
+echo "Status: install ok installed" >> $DIR/var/lib/dpkg/status.d/$NAME/control
+# add empty line at the end, will become separator in merge
+echo "" >> $DIR/var/lib/dpkg/status.d/$NAME/control

--- a/robot-agent/aptLocal.sh
+++ b/robot-agent/aptLocal.sh
@@ -2,46 +2,9 @@
 
 set -e
 
-BLACK="\033[30m"
-RED="\033[31m"
-GREEN="\033[32m"
-YELLOW="\033[33m"
-BLUE="\033[34m"
-PINK="\033[35m"
-CYAN="\033[36m"
-WHITE="\033[37m"
-NORMAL="\033[0;39m"
-
-printStep() {
-  printf "\n$GREEN$@$NORMAL\n"
-}
-
-getROSRelease() {
-  case $(lsb_release -sc) in
-    xenial) echo kinetic;;
-    bionic) echo melodic;;
-    focal) echo noetic;;
-  esac
-}
-
-BASEDIR=$(dirname $0)
-DIR=~/.transitive
-
-# ROS_RELEASE=$(ls -1 --color=never ~/.transitive/opt/ros | head -n 1)
-# ^^ would fail if no ros packages were yet installed
-ROS_RELEASE=$(getROSRelease)
+. $(dirname $0)/aptCommon.sh
 
 # -------------------------------------------------------------------------
-
-printStep "Preparing local folders"
-mkdir -p $DIR/var/lib/apt/lists/partial
-mkdir -p $DIR/var/cache/apt/archives/partial
-mkdir -p $DIR/etc/apt/{apt.conf.d,sources.list.d,preferences.d,trusted.gpg.d,keyrings}
-mkdir -p $DIR/var/log/apt
-echo "dir \"$DIR\";" > $DIR/etc/apt/apt.conf
-#echo "Dir::State::status \"$DIR/var/lib/dpkg/status\";"
-export APT_CONFIG=$DIR/etc/apt/apt.conf
-
 
 # Assemble dpkg status file, including our local additions
 printStep "Merging local and system dpkg status"
@@ -55,32 +18,7 @@ for p in $(ls $DIR/var/lib/dpkg/status.d/); do
 done
 cat $(ls $DIR/var/lib/dpkg/status.d/.merged/* | xargs) > $DIR/var/lib/dpkg/status
 
-
-printStep "Set apt sources"
-# ROS
-cp {,$DIR}/etc/apt/sources.list
-if [[ -z $ROS_RELEASE ]]; then
-  echo "No ROS1 release for $(lsb_release -sc)";
-  # remove it in case an older version of aptLocal added it:
-  rm -rf $DIR/etc/apt/sources.list.d/ros-latest.list
-else
-  echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > $DIR/etc/apt/sources.list.d/ros-latest.list
-fi;
-
-if [[ -e /etc/apt/trusted.gpg ]]; then cp {,$DIR}/etc/apt/trusted.gpg; fi
-cp /etc/apt/trusted.gpg.d/* $DIR/etc/apt/trusted.gpg.d || true
-# For now, always get latest ROS repo keys, to mitigate stuff like:
-# https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669
-printStep "Import ROS repo keys"
-curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | unshare -rm apt-key --keyring $DIR/etc/apt/trusted.gpg.d/ros.gpg add -
-
-# node.js:
-ARCH=$(dpkg --print-architecture)
-echo "deb [arch=$ARCH signed-by=$DIR/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" > $DIR/etc/apt/sources.list.d/nodesource.list
-echo "deb [arch=$ARCH signed-by=$DIR/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" >> $DIR/etc/apt/sources.list.d/nodesource.list
-rm -f $DIR/etc/apt/keyrings/nodesource.gpg
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o $DIR/etc/apt/keyrings/nodesource.gpg
-
+setupSources
 
 printStep "Running apt-get update"
 apt-get update
@@ -138,21 +76,16 @@ done
 
 
 # Generate env file for using these locally installed packages
-
+M_ARCH=$(uname -m)
 cat > $DIR/etc/env_local << EOF
 # environment variables for using debian packages installed via aptLocal.sh
 # i.e., locally in ~/.transitive
 
-# export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:$DIR/lib/$(uname -m)-linux-gnu:$DIR/usr/lib/$(uname -m)-linux-gnu/:$DIR/usr/lib/:$DIR/opt/ros/$ROS_RELEASE/lib/
-export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:$DIR/lib/$(uname -m)-linux-gnu:$DIR/usr/lib/$(uname -m)-linux-gnu/:$DIR/usr/lib/
-
-# export ROS_PACKAGE_PATH=\$ROS_PACKAGE_PATH:$DIR/opt/ros/$ROS_RELEASE/share
-
-# export CMAKE_PREFIX_PATH=\$CMAKE_PREFIX_PATH:$DIR/opt/ros/$ROS_RELEASE
+export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:$DIR/lib/${M_ARCH}-linux-gnu:$DIR/usr/lib/${M_ARCH}-linux-gnu/:$DIR/usr/lib/
 
 export PYTHONPATH=\$PYTHONPATH:$DIR/usr/lib/python2.7/dist-packages:$DIR/usr/lib/python3/dist-packages
 
 export PATH=\$PATH:$DIR/usr/sbin:$DIR/usr/bin:$DIR/sbin:$DIR/bin
 
-export PKG_CONFIG_PATH=\$PKG_CONFIG_PATH:$DIR/usr/lib/$(uname -m)-linux-gnu/pkgconfig
+export PKG_CONFIG_PATH=\$PKG_CONFIG_PATH:$DIR/usr/lib/${M_ARCH}-linux-gnu/pkgconfig
 EOF

--- a/robot-agent/commands.js
+++ b/robot-agent/commands.js
@@ -94,11 +94,13 @@ const commands = {
       log.warn(`Unable to move ${npmFolder}`, e);
     }
 
-    const cmd = `${constants.TRANSITIVE_DIR}/bin/aptLocal.sh --reinstall nodejs`;
-    // note: --reinstall ensures the npmFolder is reinstalled if successful
+    const cmd = `${__dirname}/aptFetch.sh nodejs`;
+    // using aptFetch instead of aptLocal ensures that it will work even when
+    // there are conflicting packages installed, such as node 10, see
+    // #377#issuecomment-2041523598
     exec(cmd, (err, stdout, stderr) => {
       if (err) {
-        cb(`Failed to upgrade nodejs: ${err}`);
+        log.warn(`Failed to upgrade nodejs: ${err}`);
         // we failed, restore old npm
         try {
           fs.renameSync(npmBackup, npmFolder);

--- a/robot-agent/localApi.js
+++ b/robot-agent/localApi.js
@@ -36,7 +36,8 @@ const handlers = {
         // we have passwordless sudo, let's use that
         'sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y' :
         // we have neither, use aptLocal.sh
-        `${constants.TRANSITIVE_DIR}/bin/aptLocal.sh`
+        // `${constants.TRANSITIVE_DIR}/bin/aptLocal.sh`
+        `${__dirname}/aptLocal.sh`
       )
     );
     exec(`${aptCmd} ${filteredPackages.join(' ')}`,

--- a/robot-agent/package-lock.json
+++ b/robot-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@transitive-robotics/robot-agent",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@transitive-robotics/robot-agent",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/robot-agent/package.json
+++ b/robot-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitive-robotics/robot-agent",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "The Transitive Robotics robot agent, responsible for installing and starting capability packages on the device and relaying mqtt communication.",
   "main": "index.js",
   "scripts": {

--- a/robot-agent/postinstall.sh
+++ b/robot-agent/postinstall.sh
@@ -19,7 +19,7 @@ mkdir -p ~/.transitive/usr/bin
 mkdir -p ~/.transitive/bin
 
 [ ! -e ~/.transitive/etc/env_local ] && touch ~/.transitive/etc/env_local
-cp uninstall.sh aptLocal.sh dpkgStatus.sh startPackage.sh ~/.transitive/bin
+cp uninstall.sh startPackage.sh ~/.transitive/bin
 cp unshare*.sh start_agent.sh generate_certs.sh ~/.transitive/
 
 if [ -d /run/systemd/system ]; then


### PR DESCRIPTION
- aptFetch: downloads and unpacks .deb files without checking for conflicts
  - Fixes #377#issuecomment-2041523598
- aptCommon: code shared by aptLocal and aptFetch
- localApi: use aptLocal directly from package folder (removed cp from postinstall)