### PR TITLE
proxy: fix mem leak

### DIFF
--- a/cloud/proxy/index.js
+++ b/cloud/proxy/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const os = require('os');
 const fs = require('fs');
 
 /** try parsing JSON, return null if unsuccessful */
@@ -24,7 +23,7 @@ console.log({host, production});
 
 // ------------------------------------------------------------------
 
-const proxy = require('http-proxy').createProxyServer({ xfwd: true });
+const proxy = require('http-proxy-node16').createProxyServer({ xfwd: true });
 // catches error events during proxying
 proxy.on('error', function(err, req, res) {
   console.error(err);

--- a/cloud/proxy/package-lock.json
+++ b/cloud/proxy/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "greenlock-express": "^4.0.3",
-        "http-proxy": "^1.18.1",
+        "http-proxy-node16": "^1.0.3",
         "jsonwebtoken": "^8.5.1",
         "mongodb": "^3.6.5"
       }
@@ -236,10 +236,10 @@
         "safe-replace": "^1.1.0"
       }
     },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+    "node_modules/http-proxy-node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http-proxy-node16/-/http-proxy-node16-1.0.3.tgz",
+      "integrity": "sha512-GReWWNIbJUCqYP7vcaaOGX0T+o8BpSP2VTZ4nCebJ9nbl3seUr5gCnLNpc4R2D0BK6kSY2hTsdpEV3QH2TobDg==",
       "dependencies": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -695,10 +695,10 @@
         "safe-replace": "^1.1.0"
       }
     },
-    "http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+    "http-proxy-node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http-proxy-node16/-/http-proxy-node16-1.0.3.tgz",
+      "integrity": "sha512-GReWWNIbJUCqYP7vcaaOGX0T+o8BpSP2VTZ4nCebJ9nbl3seUr5gCnLNpc4R2D0BK6kSY2hTsdpEV3QH2TobDg==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",

--- a/cloud/proxy/package.json
+++ b/cloud/proxy/package.json
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "greenlock-express": "^4.0.3",
-    "http-proxy": "^1.18.1",
+    "http-proxy-node16": "^1.0.3",
     "jsonwebtoken": "^8.5.1",
     "mongodb": "^3.6.5"
   }


### PR DESCRIPTION
- Now using http-proxy-node16, a fork from a community member since the original package seems unmaintained, that fixes a mem leak that was apparently introduced by a change in node.js 15.

Fixes #502.