### PR TITLE
Hotfix for mqtt c++ auth: subscribe is read-only

### DIFF
--- a/cloud/mosquitto/auth-transitive/mosquitto_auth_transitive.cpp
+++ b/cloud/mosquitto/auth-transitive/mosquitto_auth_transitive.cpp
@@ -467,7 +467,9 @@ static int acl_callback(int event, void *event_data, void *userdata) {
       return MOSQ_ERR_SUCCESS;
     }
 
-    if (isAuthorized(topicParts, username, ed->access == MOSQ_ACL_READ)) {
+    bool readAccess =
+      ed->access == MOSQ_ACL_READ || ed->access == MOSQ_ACL_SUBSCRIBE;
+    if (isAuthorized(topicParts, username, readAccess)) {
       // add to cache
       clientPermissions[id][ed->topic] = currentTime;
       return MOSQ_ERR_SUCCESS;

--- a/cloud/mosquitto/auth-transitive/tests.cpp
+++ b/cloud/mosquitto/auth-transitive/tests.cpp
@@ -32,6 +32,9 @@ TEST_CASE("isAuthorized") {
   std::vector<std::string> topicAgent =
     split("/user1/dev1/@transitive-robotics/_robot-agent/0.1.2/myfield", '/');
 
+  std::vector<std::string> topicAgentWild =
+    split("/user1/dev1/@transitive-robotics/_robot-agent/+/status/#", '/');
+
   std::vector<std::string> topicSubs =
     split("/user1/dev1/@scope/capName/0.1.2/myfield/sub1/sub2", '/');
 
@@ -173,6 +176,9 @@ TEST_CASE("isAuthorized") {
       }
       SUBCASE("") {
         CHECK( isAuthorized(topicAgent, simpleDevPermission.str(), true) );
+      }
+      SUBCASE("") {
+        CHECK( isAuthorized(topicAgentWild, simpleDevPermission.str(), true) );
       }
       SUBCASE("") {
         std::stringstream s;


### PR DESCRIPTION
This fixes a regression introduced in the new c++ auth plugin. Subscribe requests are read-only requests for auth.