### PR TITLE
Mosquitto auth fixes

### DIFF
--- a/cloud/mosquitto/Dockerfile
+++ b/cloud/mosquitto/Dockerfile
@@ -47,9 +47,8 @@ ADD https://github.com/doctest/doctest/releases/download/v2.4.11/doctest.h \
 # Build the plugin
 WORKDIR /build/mosq/plugins/auth-transitive
 COPY auth-transitive .
-# RUN gcc -I../../include -I../.. -fPIC -shared mosquitto_auth_transitive.c \
-#   -o /mosquitto/mosquitto_auth_transitive.so -fmax-errors=1
-RUN g++ -std=c++2a -Wfatal-errors -fPIC -shared -fmax-errors=1 -O2 \
+
+RUN g++ -std=c++2a -Wfatal-errors -fPIC -shared -fmax-errors=1 -O2 -fno-inline \
   -I../../include -I../.. -I/tmp/jwt-cpp-0.7.0/include/ \
   mosquitto_auth_transitive.cpp -o /mosquitto/mosquitto_auth_transitive.so \
   $(pkg-config --cflags --libs libmongocxx)

--- a/cloud/mosquitto/auth-transitive/compile.sh
+++ b/cloud/mosquitto/auth-transitive/compile.sh
@@ -1,1 +1,1 @@
-g++ -std=c++2a -Wfatal-errors -fPIC -shared -fmax-errors=1 -O2 -I../../include -I../.. -I/tmp/jwt-cpp-0.7.0/include/   mosquitto_auth_transitive.cpp -o /mosquitto/mosquitto_auth_transitive.so   $(pkg-config --cflags --libs libmongocxx)
+g++ -std=c++2a -Wfatal-errors -fPIC -shared -fmax-errors=1 -O2 -fno-inline -I../../include -I../.. -I/tmp/jwt-cpp-0.7.0/include/   mosquitto_auth_transitive.cpp -o /mosquitto/mosquitto_auth_transitive.so   $(pkg-config --cflags --libs libmongocxx)

--- a/cloud/mosquitto/auth-transitive/isAuthorized.hpp
+++ b/cloud/mosquitto/auth-transitive/isAuthorized.hpp
@@ -71,9 +71,10 @@ topic, decide whether the user should be granted access to the given topic.
 static int isAuthorized(std::vector<std::string> topicParts, std::string username,
   bool readAccess = false) {
 
+  if (topicParts.size() < 5) return false;
+
   auto doc = bsoncxx::from_json(username);
   auto permitted = doc["payload"];
-
 
   // requested
   auto org = topicParts[1];
@@ -81,7 +82,7 @@ static int isAuthorized(std::vector<std::string> topicParts, std::string usernam
   auto capability = topicParts[3] + '/' + topicParts[4];
 
   /// join the topicParts of the sub-topic
-  std::string sub = std::accumulate(
+  std::string sub = topicParts.size() < 7 ? "" : std::accumulate(
     std::next(topicParts.begin() + 6), topicParts.end(), topicParts[6],
     [](std::string a, std::string b) { return a + "/" + b; }
   );

--- a/cloud/mosquitto/auth-transitive/mosquitto_auth_transitive.cpp
+++ b/cloud/mosquitto/auth-transitive/mosquitto_auth_transitive.cpp
@@ -163,7 +163,7 @@ void refetchUsers() {
 }
 
 /** Print all read counts. For each user and cap, print read bytes. */
-int printReadCounts() {
+void printReadCounts() {
   for (auto it = users.cbegin(); it != users.cend(); ++it) {
     auto cap_usage = it->second.cap_usage;
     for (auto it2 = cap_usage.cbegin(); it2 != cap_usage.cend(); ++it2) {
@@ -171,7 +171,6 @@ int printReadCounts() {
       << it2->second << endl;
     }
   }
-  return 0; // We need to return *something* to avoid being optimized away
 }
 
 /** Record current meter readings in Mongo. */
@@ -371,10 +370,6 @@ typedef struct lastTime_struct {
   int minute = 0;
 } lastTime;
 
-// Used to prevent prints to be optimized away see
-// https://stackoverflow.com/a/1152574/1087119.
-static volatile int ignore = 0;
-
 /** A "cron" function, called regularly, it checks for jobs that need to run */
 static void cron() {
 
@@ -389,7 +384,7 @@ static void cron() {
     // cout << "new minute: " << now_tm->tm_min << endl;
     last.minute = now_tm->tm_min;
 
-    ignore = printReadCounts();
+    printReadCounts();
   }
 
   if (now_tm->tm_hour > last.hour) {

--- a/cloud/mosquitto/auth-transitive/tests.cpp
+++ b/cloud/mosquitto/auth-transitive/tests.cpp
@@ -38,6 +38,9 @@ TEST_CASE("isAuthorized") {
   std::vector<std::string> topicSubs =
     split("/user1/dev1/@scope/capName/0.1.2/myfield/sub1/sub2", '/');
 
+  std::vector<std::string> shortTopic = split("/user1/dev1/", '/');
+  std::vector<std::string> veryShortTopic = split("#", '/');
+
   std::stringstream simpleDevPermission;
   simpleDevPermission << R"({ "id": "user1", "payload": {
   "id": "user1", "device": "dev1", "capability": "@scope/capName",
@@ -54,6 +57,26 @@ TEST_CASE("isAuthorized") {
 
   SUBCASE("simple fleet permission") {
     CHECK( isAuthorized(topic1, simpleFleetPermission.str()) );
+  }
+
+  SUBCASE("gracefully fails on missing iat") {
+    CHECK( !isAuthorized(topic1, std::string(R"({ "id": "user1", "payload": {
+        "id": "user1", "device": "dev1", "capability": "@scope/capName",
+        "validity": 1000 }})")) );
+  }
+
+  SUBCASE("gracefully fails on missing validity") {
+    CHECK( !isAuthorized(topic1, std::string(R"({ "id": "user1", "payload": {
+        "id": "user1", "device": "dev1", "capability": "@scope/capName",
+        "iat": 1722227248 }})")) );
+  }
+
+  SUBCASE("gracefully fails on topics that are too short") {
+    CHECK( !isAuthorized(shortTopic, simpleDevPermission.str()) );
+  }
+
+  SUBCASE("gracefully fails on topics that are too short") {
+    CHECK( !isAuthorized(veryShortTopic, simpleDevPermission.str()) );
   }
 
   SUBCASE("wrong user") {


### PR DESCRIPTION
- Set gcc options to avoid removal of prints.
- Fixes bad_alloc exception when requested topic is too short.
- Also found another failure case, when provided jwt token is not a valid JWT token (wrong format).

Fixes #519.

