### PR TITLE
mqtt metering: record usage on fixed interval

### DIFF
--- a/cloud/mosquitto/Dockerfile
+++ b/cloud/mosquitto/Dockerfile
@@ -48,7 +48,7 @@ ADD https://github.com/doctest/doctest/releases/download/v2.4.11/doctest.h \
 WORKDIR /build/mosq/plugins/auth-transitive
 COPY auth-transitive .
 
-RUN g++ -std=c++2a -Wfatal-errors -fPIC -shared -fmax-errors=1 -O2 -fno-inline \
+RUN g++ -std=c++2a -Wfatal-errors -fPIC -shared -fmax-errors=1 \
   -I../../include -I../.. -I/tmp/jwt-cpp-0.7.0/include/ \
   mosquitto_auth_transitive.cpp -o /mosquitto/mosquitto_auth_transitive.so \
   $(pkg-config --cflags --libs libmongocxx)

--- a/cloud/mosquitto/auth-transitive/compile.sh
+++ b/cloud/mosquitto/auth-transitive/compile.sh
@@ -1,1 +1,1 @@
-g++ -std=c++2a -Wfatal-errors -fPIC -shared -fmax-errors=1 -O2 -fno-inline -I../../include -I../.. -I/tmp/jwt-cpp-0.7.0/include/   mosquitto_auth_transitive.cpp -o /mosquitto/mosquitto_auth_transitive.so   $(pkg-config --cflags --libs libmongocxx)
+g++ -std=c++2a -Wfatal-errors -fPIC -shared -fmax-errors=1 -I../../include -I../.. -I/tmp/jwt-cpp-0.7.0/include/   mosquitto_auth_transitive.cpp -o /mosquitto/mosquitto_auth_transitive.so   $(pkg-config --cflags --libs libmongocxx)


### PR DESCRIPTION
- Also stopped using gcc optimization, to ensure we see all output
- It seemed that, prior to this, metering wasn't running (see #536)
- now also resetting the cap usage when as new month is detected (while running; no reset of month on restart)
  - see #503