### PR TITLE
Portal: do not parse req body before proxying to caps servers

### DIFF
--- a/cloud/app/package-lock.json
+++ b/cloud/app/package-lock.json
@@ -23,7 +23,7 @@
         "express": "^4.17.1",
         "express-openid-connect": "^2.17.1",
         "express-session": "^1.17.2",
-        "http-proxy": "^1.18.1",
+        "http-proxy-node16": "^1.0.3",
         "jest": "^28.1.0",
         "json-logic-js": "^2.0.2",
         "jsonwebtoken": "^8.5.1",
@@ -6397,19 +6397,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/http-proxy-agent": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
@@ -6445,6 +6432,20 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/http-proxy-node16": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-node16/-/http-proxy-node16-1.0.5.tgz",
+      "integrity": "sha512-pBBZEJ7g22pyioXL+cIf4Vfu9r5xkcre+6NIe2fSAVQn6YvrsXwy7gtkDiOzAtQUXCvgadT7QBLGapIl/98H1g==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
@@ -17557,16 +17558,6 @@
         "toidentifier": "1.0.1"
       }
     },
-    "http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "requires": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      }
-    },
     "http-proxy-agent": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
@@ -17597,6 +17588,16 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
+      }
+    },
+    "http-proxy-node16": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-node16/-/http-proxy-node16-1.0.5.tgz",
+      "integrity": "sha512-pBBZEJ7g22pyioXL+cIf4Vfu9r5xkcre+6NIe2fSAVQn6YvrsXwy7gtkDiOzAtQUXCvgadT7QBLGapIl/98H1g==",
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "http2-wrapper": {

--- a/cloud/app/package.json
+++ b/cloud/app/package.json
@@ -18,7 +18,7 @@
     "express": "^4.17.1",
     "express-openid-connect": "^2.17.1",
     "express-session": "^1.17.2",
-    "http-proxy": "^1.18.1",
+    "http-proxy-node16": "^1.0.3",
     "jest": "^28.1.0",
     "json-logic-js": "^2.0.2",
     "jsonwebtoken": "^8.5.1",

--- a/cloud/app/server/server.js
+++ b/cloud/app/server/server.js
@@ -233,10 +233,13 @@ const app = express();
 
 app.use(express.static(path.join(cwd, 'public')));
 app.use(cors(), express.static(path.join(cwd, 'dist')));
-app.use(express.json());
 
 const capsRouter = express.Router();
 app.use('/caps', capsRouter);
+
+// Needs to come *after* capsRouter, to allow per-capability servers to parse
+// the body when it arrives there.
+app.use(express.json());
 
 const addCapsRoutes = () => {
   log.debug('adding caps router');
@@ -255,7 +258,7 @@ const addCapsRoutes = () => {
 
   /** Trades our token for a JWT with the permissions that were granted to
   this token when it was created. */
-  capsRouter.post('/getJWTFromToken', async (req, res) => {
+  capsRouter.post('/getJWTFromToken', express.json(), async (req, res) => {
     log.debug('tokenSession', req.session);
 
     log.debug('get JWT from simple access token', req.body);
@@ -305,7 +308,7 @@ const addCapsRoutes = () => {
   /** If the client already has a JWT, it can set it for the session here.
   * This will authenticate him for capability routes who can just check the
   * cookie. */
-  capsRouter.post('/setSessionJWT', async (req, res) => {
+  capsRouter.post('/setSessionJWT', express.json(), async (req, res) => {
     log.debug('setting session JWT', req.body);
     const {token} = req.body;
     res.cookie(TOKEN_COOKIE, JSON.stringify({token}))


### PR DESCRIPTION
Fixes an issue where request bodies were not available in cloud cap web servers. This was because they were already parsed in the portal server (reverse proxy for caps servers).