### PR TITLE
Serve bundles from registry

### DIFF
--- a/cloud/app/assets/cloud_runner.js
+++ b/cloud/app/assets/cloud_runner.js
@@ -8,7 +8,6 @@ symlinks created by docker.js.
 const fs = require('fs');
 const {exec, execSync, spawn} = require('child_process');
 
-const STATUS_FILE = 'run/status.json';
 const packageName = process.argv[2];
 
 const log = {};
@@ -21,9 +20,6 @@ if (!packageName) {
 }
 
 const pkgPath = `node_modules/${packageName}`;
-
-// Copy capability's web components to cloud-agent for serving
-
 let capProcess = null;
 
 /** (Re-)Start the capability process */
@@ -35,12 +31,6 @@ const restart = () => {
     process.kill(-capProcess.pid);
     // Note the minus: this kills the process group, not just `npm run cloud`
   }
-
-  // Copy web bundles to mounted run folder host.
-  // TODO let the cloud serve these bundles directly without cooperation from
-  // the cloud cap (that will also make sure we always serve the latest for the
-  // version, e.g., using `npm install --ignore-scripts` based on running version.
-  execSync(`cp -a ${pkgPath}/dist ${pkgPath}/package.json run`);
 
   capProcess = spawn('npm', ['run', 'cloud'],
     {cwd: pkgPath, stdio: 'inherit', detached: true});

--- a/cloud/app/server/docker.js
+++ b/cloud/app/server/docker.js
@@ -177,8 +177,6 @@ const portsUsedByUs = [];
 const start = async ({name, version, pkgInfo}) => {
 
   const tagName = getTagName({name, version});
-  const runDir = path.join(RUN_DIR, name, version);
-  fs.mkdirSync(runDir, {recursive: true});
   const list = await docker.listImages();
   const exists = list.some(image =>
     image.RepoTags && image.RepoTags.includes(tagName));
@@ -201,7 +199,6 @@ const start = async ({name, version, pkgInfo}) => {
     AutoRemove: true,
     // expose app run folder to host, we are hosting the js bundle here
     Binds: [
-      `${runDir}:/app/run`,
       `${process.env.TR_VAR_DIR}/caps/common:/persistent/common`,
       `${process.env.TR_VAR_DIR}/caps/${name}:/persistent/self`,
     ],

--- a/cloud/docker-compose.yaml
+++ b/cloud/docker-compose.yaml
@@ -57,6 +57,29 @@ x-mosquitto: &shared_mosquitto
         cpus: '0.9'
         memory: 250M
 
+x-registry: &shared_registry
+  container_name: registry
+  build: ./registry
+  image: transitiverobotics/registry:latest
+  restart: always
+  depends_on:
+    - mongodb
+  env_file:
+    - .env
+  ports:
+    - 6000:6000
+  networks:
+    - default
+    - shared
+    - caps
+  logging:
+    driver: local
+  deploy:
+    resources:
+      limits:
+        cpus: '0.7'
+        memory: 500M
+
 
 networks:
   caps:
@@ -121,7 +144,7 @@ services:
       target: prod
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /run/user/0:/run/user/0
+      # - /run/user/0:/run/user/0
       - ${TR_VAR_DIR:-.}/certs:/etc/mosquitto/certs
 
   cloud_dev:
@@ -136,15 +159,12 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${TR_VAR_DIR:-.}/certs:/etc/mosquitto/certs
-      - /run/user/0:/run/user/0
+      # - /run/user/0:/run/user/0
       - ./app/src:/app/src
       - ./app/web_components:/app/web_components
       - ./app/server:/app/server
       - ./app/assets:/app/assets
       - ./app/public:/app/public
-      # In dev we allow serving local dev files for capability bundles. This
-      # assumes a specific directory layout.
-      - /tmp/caps:/app/caps:ro
 
   proxy:
     build: ./proxy
@@ -168,34 +188,39 @@ services:
           cpus: '0.9'
           memory: 300M
 
-  registry:
-    build: ./registry
-    image: transitiverobotics/registry:latest
-    restart: always
-    depends_on:
-      - mongodb
-    env_file:
-      - .env
-    ports:
-      - 6000:6000
-    networks:
-      - default
-      - shared
-      - caps
-    logging:
-      driver: local
-    deploy:
-      resources:
-        limits:
-          cpus: '0.7'
-          memory: 500M
+  registry_prod:
+    <<: *shared_registry
+    profiles:
+      - prod
+
+  registry_dev:
+    <<: *shared_registry
+    profiles:
+      - dev
+    volumes:
+      - ./registry/index.js:/app/index.js
+      # In dev we allow serving local dev files for capability bundles. This
+      # assumes a specific directory layout.
+      - /tmp/caps:/app/caps:ro
 
   # Once the registry is up, republish the robot-agent to it, in case it changed
-  publish:
+  publish_prod:
+    profiles:
+      - prod
     build: ../robot-agent
     image: transitiverobotics/publish_agent:latest
     depends_on:
-      - registry
+      - registry_prod
+    env_file:
+      - .env
+
+  publish_dev:
+    profiles:
+      - dev
+    build: ../robot-agent
+    image: transitiverobotics/publish_agent:latest
+    depends_on:
+      - registry_dev
     env_file:
       - .env
 

--- a/cloud/proxy/index.js
+++ b/cloud/proxy/index.js
@@ -69,7 +69,7 @@ const handleRequest = (req, res) => {
 
 /** handler for web socket upgrade */
 const handleUpgrade = function(req, socket, head) {
-  console.log('ws:', req.headers.host, req.url);
+  console.log(`ws: ${req.socket.remoteAddress}: ${req.headers.host}${req.url}`);
   const target = getTarget(req);
   if (!target) {
     res.statusCode = 404;

--- a/cloud/registry/package.json
+++ b/cloud/registry/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node index.js"
+    "start": "while (true); do node index.js; sleep 2; done"
   },
   "keywords": [],
   "author": "",

--- a/robot-agent/generate_certs.sh
+++ b/robot-agent/generate_certs.sh
@@ -16,7 +16,7 @@ else
   . .env
   . .token
 
-  HASH=${TR_INSTALL_HASH//[^a-zA-Z0-9]/}
+  HASH=${TR_INSTALL_HASH//[^a-zA-Z0-9\-\_]/}
   if [[ -z $HASH ]]; then
     echo "  computing hashed machine-id"
     DEVICEID=$(cat /etc/machine-id)


### PR DESCRIPTION
With this change we now serve capability web bundles from the registry directly. This simplifies things a bit because now we no longer need to copy the bundles from the cloud capability container to a folder shared with the portal. This also means bundles are available immediately after a new release is published, and not only once a first robot has upgraded to it and the cloud has responded by firing up the corresponding cloud container.

This now also allows us to serve the special `latest` version of a bundle (used for fleet widgets). This is required for transAct to work even without any robot in the fleet running ros-tool (and hence no running version being found).