### PR TITLE
Agent multi pings, dev docker container

### DIFF
--- a/cloud/app/src/utils/index.jsx
+++ b/cloud/app/src/utils/index.jsx
@@ -1,9 +1,10 @@
 import React, {forwardRef} from 'react';
 
 /** A link (anchor) that can be used as a button */
-export const ActionLink = forwardRef(({onClick, disabled, children}, ref) => {
-  const style = {
-  };
+export const ActionLink = forwardRef((props, ref) => {
+  const {onClick, onContextMenu, disabled, children} = props;
+
+  const style = {};
   disabled && Object.assign(style, {
     opacity: '0.5'
   });
@@ -14,5 +15,12 @@ export const ActionLink = forwardRef(({onClick, disabled, children}, ref) => {
       e.preventDefault();
       onClick();
       return false;
-    }}>{children}</a>;
+    }}
+    onContextMenu={(e) => {
+      e.preventDefault();
+      console.log('onContextMenu', onContextMenu);
+      onContextMenu?.();
+      return false;
+    }}
+    >{children}</a>;
 });

--- a/robot-agent/.gitignore
+++ b/robot-agent/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 revertuid
+tr_docker

--- a/robot-agent/Dockerfile-dev
+++ b/robot-agent/Dockerfile-dev
@@ -1,0 +1,6 @@
+# A Dockerfile for building a slightly extended docker image for testing the
+# agent in a docker container from source. See run_in_docker.sh.
+
+FROM transitiverobotics/try_noetic
+
+RUN apt update && apt install -y iproute2

--- a/robot-agent/mqtt.js
+++ b/robot-agent/mqtt.js
@@ -125,6 +125,14 @@ mqttClient.on('connect', function(connackPacket) {
       mqttSync.publish(`${AGENT_PREFIX}/info`);
       mqttSync.publish(`${AGENT_PREFIX}/status`);
 
+      // for ongoing ping checking (not to be confused with ping RPC command)
+      mqttSync.subscribe(`${AGENT_PREFIX}/client/ping`);
+      mqttSync.data.subscribePath(`${AGENT_PREFIX}/client/ping`, ping => {
+        log.debug(`ping: ${ping}`);
+        mqttSync.data.update(`${AGENT_PREFIX}/status/pong`,
+          {ping, pong: Date.now()});
+      });
+
       staticInfo();
 
       heartbeat();

--- a/robot-agent/run_in_docker.sh
+++ b/robot-agent/run_in_docker.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Run the local robot-agent source code in a docker container. Allows testing
+# changes. Restart agent from portal after editing local robot-agent files for
+# the changes to take effect.
+
+source ../cloud/.env
+
+docker build -f Dockerfile-dev -t tr-robot-agent-dev .
+
+echo "Looking up robot token"
+TOKEN=$(docker exec cloud-mongodb-1 mongosh transitive --quiet --eval "db.accounts.findOne({_id: '${TR_USER}'}).robotToken")
+
+if [[ ! -e $PWD/tr_docker ]]; then
+  echo "Create docker container to populate tr_docker";
+  timeout 20 docker run --rm --privileged -v $PWD/tr_docker:/root/.transitive \
+  --name tr-robot-source \
+  --hostname robot-source \
+  tr-robot-agent-dev $TR_USER ${TOKEN} http://install.$TR_HOST
+fi;
+
+echo "Now start container with existing installation, but use local agent source"
+docker run -it --rm --privileged \
+  -v $PWD/tr_docker:/root/.transitive \
+  -v $PWD:/root/.transitive/node_modules/@transitive-robotics/robot-agent \
+  -v /run/udev:/run/udev \
+  -v /var/run/dbus:/var/run/dbus \
+  -v /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket \
+  --name tr-robot-source \
+  --hostname robot-source \
+  tr-robot-agent-dev $TR_USER ${TOKEN} http://install.$TR_HOST
+


### PR DESCRIPTION
[robot-agent: new feature to send 10 pings (over mqttsync)](https://github.com/transitiverobotics/transitive/commit/90c2a7e1dfd19df6150d1d566b650fbd1a8484fb) 

- This allows us to test the reliability of mqtt over poor networks.
- Tested with 50% packet loss: still every single ping and responding pong arrived, just with a few seconds delay at times.
- To active: right-click on the Ping link in the agent UI, then check the dev console for responses incl. round-trip times.

Fixes #550.

[robot-agent: script and Dockerfile to test agent in docker (from source)](https://github.com/transitiverobotics/transitive/commit/0e6868407d51b82dea5889c4a4d7a1e633d722d9) 

- primary purpose is to allow instrumenting the container for #550, i.e., simulating packet loss and other adverse network situations.


Note: no version increase here, so this won't get published as a new robot-agent version yet.