### PR TITLE
device config refreshed on file change

### DIFF
--- a/robot-agent/commands.js
+++ b/robot-agent/commands.js
@@ -58,17 +58,14 @@ const commands = {
   updateConfig: ({modifier}) => {
     log.debug('updateConfig', modifier);
     // now set it in `global.config` and write it back to disk
-    _.forEach(modifier, (value, path) => _.set(global.config, path, value));
-    log.debug('backing up old config and writing new', global.config);
+    const newConfig = clone(global.config);
+    _.forEach(modifier, (value, path) => _.set(newConfig, path, value));
+    log.debug('backing up old config and writing new', newConfig);
     try {
       fs.copyFileSync('./config.json', './config.json.bak');
     } catch (e) {}
-    fs.writeFileSync('./config.json', JSON.stringify(global.config, true, 2),
+    fs.writeFileSync('./config.json', JSON.stringify(newConfig, true, 2),
       {encoding: 'utf8'});
-
-    global.data.update(`${global.AGENT_PREFIX}/info/config`,
-      clone(global.config)
-    );
   },
 
   upgradeNodejs: () => {

--- a/robot-agent/config.js
+++ b/robot-agent/config.js
@@ -7,21 +7,23 @@ dotenv.config({path: './.env_user'});
 global.config = {};
 const fleetConfig = {};
 
+const configChangeHandlers = [];
+
 const refreshGlobalConfig = () => {
   try {
     global.config = JSON.parse(fs.readFileSync('./config.json', {encoding: 'utf8'}));
     console.log(`Using config:\n${JSON.stringify(global.config, true, 2)}`);
+    // Notify all handlers of the config change
+    configChangeHandlers.forEach(handler => handler(global.config));
   } catch (e) {
     console.log('No config.json file found or not valid JSON, proceeding without.');
   }
 };
 refreshGlobalConfig();
 
-fs.watchFile('./config.json', {interval: 1000}, (curr, prev) => {
-  if (curr.mtime !== prev.mtime) {
-    console.log('Reloading config.json');
-    refreshGlobalConfig();
-  }
+fs.watch('./config.json', {interval: 1000}, (curr, prev) => {
+  console.log('Reloading config.json');
+  refreshGlobalConfig();
 });
 
 /** Set the `key` in the fleet config to `value` */
@@ -33,4 +35,8 @@ const getConfig = (key) =>
   ? global.config[key]
   : fleetConfig[key];
 
-module.exports = { updateFleetConfig, getConfig };
+const registerConfigChangeHandler = (handler) => {
+  configChangeHandlers.push(handler);
+}
+
+module.exports = { updateFleetConfig, getConfig, registerConfigChangeHandler };

--- a/robot-agent/config.js
+++ b/robot-agent/config.js
@@ -23,11 +23,12 @@ const refreshGlobalConfigFromFile = () => {
 };
 refreshGlobalConfigFromFile();
 
-fs.watch('./config.json', {persistence: false},
-  (eventType, filename) => {
+fs.watchFile('./config.json', { interval: 500 }, (curr, prev) => {
+  if (curr.mtime !== prev.mtime) {
     console.log('config.json changed, updating global config');
     refreshGlobalConfigFromFile();
-  });
+  }
+});
 
 /** Set the `key` in the fleet config to `value` */
 const updateFleetConfig = (key, value) => fleetConfig[key] = value;

--- a/robot-agent/config.js
+++ b/robot-agent/config.js
@@ -23,10 +23,11 @@ const refreshGlobalConfigFromFile = () => {
 };
 refreshGlobalConfigFromFile();
 
-fs.watch('./config.json', (curr, prev) => {
-  console.log('config.json changed, updating global config');
-  refreshGlobalConfigFromFile();
-});
+fs.watch('./config.json', {persistence: false},
+  (eventType, filename) => {
+    console.log('config.json changed, updating global config');
+    refreshGlobalConfigFromFile();
+  });
 
 /** Set the `key` in the fleet config to `value` */
 const updateFleetConfig = (key, value) => fleetConfig[key] = value;

--- a/robot-agent/config.js
+++ b/robot-agent/config.js
@@ -7,12 +7,22 @@ dotenv.config({path: './.env_user'});
 global.config = {};
 const fleetConfig = {};
 
-try {
-  global.config = JSON.parse(fs.readFileSync('./config.json', {encoding: 'utf8'}));
-  console.log(`Using config:\n${JSON.stringify(global.config, true, 2)}`);
-} catch (e) {
-  console.log('No config.json file found or not valid JSON, proceeding without.');
-}
+const refreshGlobalConfig = () => {
+  try {
+    global.config = JSON.parse(fs.readFileSync('./config.json', {encoding: 'utf8'}));
+    console.log(`Using config:\n${JSON.stringify(global.config, true, 2)}`);
+  } catch (e) {
+    console.log('No config.json file found or not valid JSON, proceeding without.');
+  }
+};
+refreshGlobalConfig();
+
+fs.watchFile('./config.json', {interval: 1000}, (curr, prev) => {
+  if (curr.mtime !== prev.mtime) {
+    console.log('Reloading config.json');
+    refreshGlobalConfig();
+  }
+});
 
 /** Set the `key` in the fleet config to `value` */
 const updateFleetConfig = (key, value) => fleetConfig[key] = value;

--- a/robot-agent/config.js
+++ b/robot-agent/config.js
@@ -23,12 +23,45 @@ const refreshGlobalConfigFromFile = () => {
 };
 refreshGlobalConfigFromFile();
 
-fs.watchFile('./config.json', { interval: 500 }, (curr, prev) => {
-  if (curr.mtime !== prev.mtime) {
-    console.log('config.json changed, updating global config');
-    refreshGlobalConfigFromFile();
+let watcher;
+
+// Wait for the file to exist before using it
+// This is useful for VI or other editors that creates a new file
+// on save, which can cause the watcher to trigger before the file is ready
+// to be read.
+const waitForFile = (filePath, callback) => {
+  const interval = setInterval(() => {
+    if (fs.existsSync(filePath)) {
+      clearInterval(interval);
+      callback();
+    }
+  }, 500);
+};
+
+const startWatchingConfig = () => {
+  if (watcher) {
+    watcher.close();
+    console.log('Previous watcher closed.');
   }
-});
+
+  waitForFile('./config.json', () => {
+    try {
+      watcher = fs.watch('./config.json', { persistence: false }, (eventType, filename) => {
+        console.log('config.json changed');
+        waitForFile('./config.json', () => {
+          refreshGlobalConfigFromFile();
+        });
+        startWatchingConfig(); // Restart the watcher
+      });
+
+      console.log('Started watching config.json');
+    } catch (err) {
+      console.error('Error setting up watcher:', err);
+    }
+  });
+};
+
+startWatchingConfig();
 
 /** Set the `key` in the fleet config to `value` */
 const updateFleetConfig = (key, value) => fleetConfig[key] = value;

--- a/robot-agent/config.js
+++ b/robot-agent/config.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const dotenv = require('dotenv');
 const { clone } = require('@transitive-sdk/utils');
+const { getInstalledPackages, updatePackageConfigFile } = require('./utils');
 
 dotenv.config({path: './.env'});
 dotenv.config({path: './.env_user'});
@@ -12,6 +13,10 @@ const refreshGlobalConfigFromFile = () => {
   try {
     global.config = JSON.parse(fs.readFileSync('./config.json', {encoding: 'utf8'}));
     console.log(`Using config:\n${JSON.stringify(global.config, true, 2)}`);
+    const packages = getInstalledPackages();
+    // generate config.json for each package
+    packages.forEach(updatePackageConfigFile);
+    // update the config in the fleet data store
     if (global.data) {
       // update the config in the fleet data store
       console.log(`Updating global config in ${global.AGENT_PREFIX}/info/config`);

--- a/robot-agent/mqtt.js
+++ b/robot-agent/mqtt.js
@@ -122,7 +122,7 @@ mqttClient.on('connect', function(connackPacket) {
       global.data = data; // #hacky; need this in commands.js
       global.AGENT_PREFIX = AGENT_PREFIX;
 
-      mqttSync.publish(`${AGENT_PREFIX}/info`);
+      mqttSync.publish(`${AGENT_PREFIX}/info`, {atomic: true});
       mqttSync.publish(`${AGENT_PREFIX}/status`);
 
       // for ongoing ping checking (not to be confused with ping RPC command)
@@ -133,14 +133,7 @@ mqttClient.on('connect', function(connackPacket) {
           {ping, pong: Date.now()});
       });
 
-      // publish device info including config
       staticInfo();
-
-      registerConfigChangeHandler((config) => {
-        console.log('config changed, republishing staticInfo');
-        staticInfo();
-      });
-
       heartbeat();
       setInterval(heartbeat, 60 * 1e3);
 

--- a/robot-agent/mqtt.js
+++ b/robot-agent/mqtt.js
@@ -134,6 +134,7 @@ mqttClient.on('connect', function(connackPacket) {
       });
 
       staticInfo();
+
       heartbeat();
       setInterval(heartbeat, 60 * 1e3);
 

--- a/robot-agent/mqtt.js
+++ b/robot-agent/mqtt.js
@@ -31,7 +31,7 @@ const { parseMQTTTopic, mqttClearRetained, MqttSync, getLogger,
 const { handleAgentCommand, commands } = require('./commands');
 const { ensureDesiredPackages } = require('./utils');
 const { startLocalMQTTBroker } = require('./localMQTT');
-const { updateFleetConfig, registerConfigChangeHandler } = require('./config');
+const { updateFleetConfig } = require('./config');
 
 const log = getLogger('mqtt.js');
 log.setLevel('info');

--- a/robot-agent/mqtt.js
+++ b/robot-agent/mqtt.js
@@ -133,7 +133,19 @@ mqttClient.on('connect', function(connackPacket) {
           {ping, pong: Date.now()});
       });
 
+      // publish device info including config
       staticInfo();
+      const globalProxy = new Proxy(global, {
+        set(target, property, value) {
+          target[property] = value;
+          if (property == 'config') {
+            console.log('config changed, republishing staticInfo');
+            staticInfo(); // Republish staticInfo on config change
+          }
+          return true;
+        }
+      });
+      global = globalProxy;
 
       heartbeat();
       setInterval(heartbeat, 60 * 1e3);

--- a/robot-agent/startPackage.sh
+++ b/robot-agent/startPackage.sh
@@ -73,8 +73,6 @@ do
   # be sure we are in the base directory before running update
   cd $BASE
 
-  # Log the TRCONFIG environment variable
-  echo "----------------------------------------- TRCONFIG: $TRCONFIG"
   # Clear out old npm folders from a potentially failed update (or whatever
   # else leaves these beind, see
   # https://docs.npmjs.com/common-errors#many-enoent--enotempty-errors-in-output.

--- a/robot-agent/startPackage.sh
+++ b/robot-agent/startPackage.sh
@@ -53,6 +53,7 @@ pid=
 
 BASE=$PWD
 STATUS_FILE="$BASE/status.json"
+CONFIG_FILE="$BASE/config.json"
 
 # trap SIGUSR1 and restart the node application
 # The `-` in front of the pid ensures that the entire process group gets killed,
@@ -72,6 +73,8 @@ do
   # be sure we are in the base directory before running update
   cd $BASE
 
+  # Log the TRCONFIG environment variable
+  echo "----------------------------------------- TRCONFIG: $TRCONFIG"
   # Clear out old npm folders from a potentially failed update (or whatever
   # else leaves these beind, see
   # https://docs.npmjs.com/common-errors#many-enoent--enotempty-errors-in-output.
@@ -103,6 +106,21 @@ do
     # record the used node modules version, since this may be the first install
     echo $CURRENT_MODULES_VERSION > .compiled_modules_version
   fi;
+
+  # Check if the config file exists, then update TRCONFIG with the contents of the file
+  if [ -e $CONFIG_FILE ]; then
+    # Check if the config file is empty
+    if [ -s $CONFIG_FILE ]; then
+      # Read the config file and set the TRCONFIG environment variable
+      export TRCONFIG=$(cat $CONFIG_FILE)
+    else
+      export TRCONFIG="{}"
+    fi
+  else
+    echo "Config file $CONFIG_FILE not found"
+  fi
+  
+  echo "TRCONFIG: $TRCONFIG"
 
   cd "$BASE/node_modules/$1"
   export PASSWORD=$(cat ../../../password)

--- a/robot-agent/startPackage.sh
+++ b/robot-agent/startPackage.sh
@@ -105,17 +105,19 @@ do
     echo $CURRENT_MODULES_VERSION > .compiled_modules_version
   fi;
 
-  # Check if the config file exists, then update TRCONFIG with the contents of the file
   if [ -e $CONFIG_FILE ]; then
-    # Check if the config file is empty
+    # Config file exists
     if [ -s $CONFIG_FILE ]; then
-      # Read the config file and set the TRCONFIG environment variable
+      # Config file is not empty
       export TRCONFIG=$(cat $CONFIG_FILE)
     else
+      # If the config file is empty
+      echo "Config file $CONFIG_FILE is empty"
       export TRCONFIG="{}"
     fi
-  else
+  else    
     echo "Config file $CONFIG_FILE not found"
+     export TRCONFIG="{}"
   fi
   
   echo "TRCONFIG: $TRCONFIG"

--- a/robot-agent/utils.js
+++ b/robot-agent/utils.js
@@ -7,7 +7,6 @@ const _ = require('lodash');
 
 const { toFlatObject, getLogger } = require('@transitive-sdk/utils');
 const constants = require('./constants');
-const { registerConfigChangeHandler } = require('./config');
 
 const log = getLogger('utils');
 log.setLevel('debug');

--- a/robot-agent/utils.js
+++ b/robot-agent/utils.js
@@ -84,7 +84,6 @@ const updatePackageConfigFile = (packageName) => {
   e.g., name = '@transitive-robotics/health-monitoring'
 */
 const restartPackage = (name, startIfNotRunning = false) => {
-  updatePackageConfigFile(name);
   killPackage(name, 'SIGUSR1', (code) => {
     if (code == 1) {
       log.warn(`package ${name} not running`);
@@ -117,7 +116,6 @@ const killPackage = (name, signal = 'SIGTERM', cb = undefined) => {
 /** start the named package if it isn't already running */
 const startPackage = (name) => {
   log.debug(`startPackage ${name}`);
-  updatePackageConfigFile(name);
 
   // first check whether it might already be running
   const pgrep = spawn('pgrep',
@@ -349,5 +347,6 @@ module.exports = {
   rotateAllLogs,
   killAllPackages,
   ensureDesiredPackages,
-  upgradeNodejs
+  upgradeNodejs,
+  updatePackageConfigFile
 };

--- a/robot-agent/utils.js
+++ b/robot-agent/utils.js
@@ -47,6 +47,7 @@ const addPackage = (addedPkg) => {
   fs.copyFileSync(`${constants.TRANSITIVE_DIR}/.npmrc`, `${dir}/.npmrc`);
   fs.writeFileSync(`${dir}/package.json`,
     `{ "dependencies": {"${addedPkg}": "*"} }`);
+  updatePackageConfigFile(addedPkg);
   startPackage(addedPkg);
 };
 


### PR DESCRIPTION
- first approach
- changes to the config.json file gets reflected on global.config object
- global object is proxied so we can refresh device data on mqttsync reacting to config changes
- I have some limited testing abilities, I can use some help on that from
  - But as far as I could test:
    - Frontend device details reflects live changes in global.rosReleases, updating the dropboxes selections, but it needs a page reload
    - I'm failing to start capabilities, unshare.sh fails, but adding a log line there I can see that the TRCONFIG env var gets updated when I hit restart for a capability on the frontend

addresses https://github.com/transitiverobotics/issues/issues/592
