### PR TITLE
Clickhouse: configure for low-ram, allow 8GB for now

### DIFF
--- a/cloud/clickhouse/Dockerfile
+++ b/cloud/clickhouse/Dockerfile
@@ -1,0 +1,4 @@
+# FROM clickhouse/clickhouse-server:24-alpine
+FROM clickhouse:25.7
+
+COPY etc/ /etc/

--- a/cloud/clickhouse/etc/clickhouse-server/config.d/50_transitive.xml
+++ b/cloud/clickhouse/etc/clickhouse-server/config.d/50_transitive.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!--
+Applying settings to reduce memory usage as recommended in
+https://clickhouse.com/docs/operations/tips#using-less-than-16gb-of-ram
+-->
+<clickhouse>
+  <mark_cache_size>524288000</mark_cache_size>
+  <!-- <concurrent_threads_soft_limit_num>1</concurrent_threads_soft_limit_num> -->
+
+  <!--
+    Recommended by AskAI when asked about MergeTreeBackgroundExecutor exception
+   -->
+  <!-- <merges_mutations_memory_usage_soft_limit>524288000</merges_mutations_memory_usage_soft_limit>
+  <merge_tree>
+    <merge_max_block_size>1024</merge_max_block_size> -->
+    <!-- <max_bytes_to_merge_at_max_space_in_pool>153741824</max_bytes_to_merge_at_max_space_in_pool>
+    <number_of_free_entries_in_pool_to_lower_max_size_of_merge>0</number_of_free_entries_in_pool_to_lower_max_size_of_merge> -->
+  <!-- </merge_tree> -->
+
+
+  <!-- From https://jamesoclaire.com/2024/12/20/clickhouse-in-less-than-2gb-ram-in-docker/ -->
+  <!-- <cache_size_to_ram_max_ratio replace="replace">0.2</cache_size_to_ram_max_ratio>
+  <max_server_memory_usage_to_ram_ratio replace="replace">2</max_server_memory_usage_to_ram_ratio> -->
+
+
+
+  <!-- From https://kb.altinity.com/altinity-kb-setup-and-maintenance/configure_clickhouse_for_low_mem_envs/ -->
+
+
+  <mlock_executable>false</mlock_executable>
+
+</clickhouse>

--- a/cloud/clickhouse/etc/clickhouse-server/users.d/50_transitive.xml
+++ b/cloud/clickhouse/etc/clickhouse-server/users.d/50_transitive.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+Applying settings to reduce memory usage as recommended in
+https://clickhouse.com/docs/operations/tips#using-less-than-16gb-of-ram.
+The settings applied here are added to the default user profile.
+-->
+
+<clickhouse>
+  <profiles>
+    <default>
+      <!-- <max_block_size>8192</max_block_size> -->
+      <max_block_size>1024</max_block_size>
+      <max_download_threads>1</max_download_threads>
+      <input_format_parallel_parsing>0</input_format_parallel_parsing>
+      <output_format_parallel_formatting>0</output_format_parallel_formatting>
+      <!-- <max_threads>2</max_threads> -->
+
+      <!-- <max_memory_usage>524288000</max_memory_usage> -->
+      <!-- <max_memory_usage>4024288000</max_memory_usage> -->
+
+
+      <!-- <max_threads>2</max_threads>
+      <queue_max_wait_ms>1000</queue_max_wait_ms>
+      <max_execution_time>600</max_execution_time>
+      <input_format_parallel_parsing>0</input_format_parallel_parsing>
+      <output_format_parallel_formatting>0</output_format_parallel_formatting>
+      <max_bytes_before_external_group_by>3221225472</max_bytes_before_external_group_by>
+      <max_bytes_before_external_sort>3221225472</max_bytes_before_external_sort> -->
+    </default>
+  </profiles>
+</clickhouse>

--- a/cloud/docker-compose.override.yaml
+++ b/cloud/docker-compose.override.yaml
@@ -77,3 +77,6 @@ services:
   # In Dev: run a small mDNS service to allow local testing with subdomains
   mdns:
     build: ./tools/mDNS
+
+  clickhouse:
+    build: ./clickhouse

--- a/cloud/docker-compose.yaml
+++ b/cloud/docker-compose.yaml
@@ -202,68 +202,71 @@ services:
   # -----------------------------------------------------------------------
   # HyperDX
 
-  # clickhouse:
-  #   image: clickhouse/clickhouse-server:24-alpine
-  #   env_file:
-  #     - .env
-  #   environment:
-  #     # default settings
-  #     CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
-  #   volumes:
-  #     - ${TR_VAR_DIR:-.}/hyperdx/ch_data:/var/lib/clickhouse
-  #     # - ${TR_VAR_DIR:-.}/hyperdx/ch_logs:/var/log/clickhouse-server
-  #   restart: always
-  #   networks:
-  #     - default
-  #   # ports:
-  #   #   - "8123:8123"  # HTTP interface for web UI and API
-  #   #   - "9002:9000"  # Native TCP interface for clients (mapped to avoid conflict 
-  #   deploy:
-  #     resources:
-  #       limits:
-  #         cpus: '0.5'
-  #         # memory: 900M
+  clickhouse:
+    # image: clickhouse/clickhouse-server:24-alpine
+    image: transitiverobotics/clickhouse:latest
+    env_file:
+      - .env
+    environment:
+      # default settings
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+    volumes:
+      - ${TR_VAR_DIR:-.}/hyperdx/ch_data:/var/lib/clickhouse
+      - ${TR_VAR_DIR:-.}/hyperdx/ch_logs:/var/log/clickhouse-server
+    restart: always
+    networks:
+      - default
+    ports:
+      - "8123:8123"  # HTTP interface for web UI and API
+      - "9002:9000"  # Native TCP interface for clients (mapped to avoid conflict
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 8192M
+        # reservations:
+        #   memory: 4096M
 
-  # hyperdx:
-  #   image: docker.hyperdx.io/hyperdx/hyperdx:2
-  #   env_file:
-  #     - .env
-  #   environment:
-  #     # FRONTEND_URL: ${HYPERDX_APP_URL:-http://localhost}:${HYPERDX_APP_PORT:-80}
-  #     FRONTEND_URL: ${HYPERDX_APP_URL:-http://localhost}
-  #     MONGO_URI: 'mongodb://mongodb:27017/hyperdx'
-  #     NEXT_PUBLIC_SERVER_URL: http://127.0.0.1:${HYPERDX_API_PORT:-8000}
-  #     OPAMP_PORT: 4320
-  #     OTEL_SERVICE_NAME: 'hdx-oss-api'
-  #     USAGE_STATS_ENABLED: ${USAGE_STATS_ENABLED:-true}
-  #     DEFAULT_CONNECTIONS:
-  #       '[{"name":"Local
-  #       ClickHouse","host":"http://clickhouse:8123","username":"default","password":""}]'
-  #     DEFAULT_SOURCES:
-  #       '[{"from":{"databaseName":"default","tableName":"otel_logs"},"kind":"log","timestampValueExpression":"TimestampTime","name":"Logs","displayedTimestampValueExpression":"Timestamp","implicitColumnExpression":"Body","serviceNameExpression":"ServiceName","bodyExpression":"Body","eventAttributesExpression":"LogAttributes","resourceAttributesExpression":"ResourceAttributes","defaultTableSelectExpression":"Timestamp,ServiceName,SeverityText,Body","severityTextExpression":"SeverityText","traceIdExpression":"TraceId","spanIdExpression":"SpanId","connection":"Local
-  #       ClickHouse","traceSourceId":"Traces","sessionSourceId":"Sessions","metricSourceId":"Metrics"},{"from":{"databaseName":"default","tableName":"otel_traces"},"kind":"trace","timestampValueExpression":"Timestamp","name":"Traces","displayedTimestampValueExpression":"Timestamp","implicitColumnExpression":"SpanName","serviceNameExpression":"ServiceName","bodyExpression":"SpanName","eventAttributesExpression":"SpanAttributes","resourceAttributesExpression":"ResourceAttributes","defaultTableSelectExpression":"Timestamp,ServiceName,StatusCode,round(Duration/1e6),SpanName","traceIdExpression":"TraceId","spanIdExpression":"SpanId","durationExpression":"Duration","durationPrecision":9,"parentSpanIdExpression":"ParentSpanId","spanNameExpression":"SpanName","spanKindExpression":"SpanKind","statusCodeExpression":"StatusCode","statusMessageExpression":"StatusMessage","connection":"Local
-  #       ClickHouse","logSourceId":"Logs","sessionSourceId":"Sessions","metricSourceId":"Metrics"},{"from":{"databaseName":"default","tableName":""},"kind":"metric","timestampValueExpression":"TimeUnix","name":"Metrics","resourceAttributesExpression":"ResourceAttributes","metricTables":{"gauge":"otel_metrics_gauge","histogram":"otel_metrics_histogram","sum":"otel_metrics_sum","_id":"682586a8b1f81924e628e808","id":"682586a8b1f81924e628e808"},"connection":"Local
-  #       ClickHouse","logSourceId":"Logs","traceSourceId":"Traces","sessionSourceId":"Sessions"},{"from":{"databaseName":"default","tableName":"hyperdx_sessions"},"kind":"session","timestampValueExpression":"TimestampTime","name":"Sessions","displayedTimestampValueExpression":"Timestamp","implicitColumnExpression":"Body","serviceNameExpression":"ServiceName","bodyExpression":"Body","eventAttributesExpression":"LogAttributes","resourceAttributesExpression":"ResourceAttributes","defaultTableSelectExpression":"Timestamp,ServiceName,SeverityText,Body","severityTextExpression":"SeverityText","traceIdExpression":"TraceId","spanIdExpression":"SpanId","connection":"Local
-  #       ClickHouse","logSourceId":"Logs","traceSourceId":"Traces","metricSourceId":"Metrics"}]'
-  #   networks:
-  #     - default
-  #   restart: always
-  #   depends_on:
-  #     - clickhouse
-  #     - mongodb
+  hyperdx:
+    image: docker.hyperdx.io/hyperdx/hyperdx:2
+    env_file:
+      - .env
+    environment:
+      # FRONTEND_URL: ${HYPERDX_APP_URL:-http://localhost}:${HYPERDX_APP_PORT:-80}
+      FRONTEND_URL: ${HYPERDX_APP_URL:-http://localhost}
+      MONGO_URI: 'mongodb://mongodb:27017/hyperdx'
+      NEXT_PUBLIC_SERVER_URL: http://127.0.0.1:${HYPERDX_API_PORT:-8000}
+      OPAMP_PORT: 4320
+      OTEL_SERVICE_NAME: 'hdx-oss-api'
+      USAGE_STATS_ENABLED: ${USAGE_STATS_ENABLED:-true}
+      DEFAULT_CONNECTIONS:
+        '[{"name":"Local
+        ClickHouse","host":"http://clickhouse:8123","username":"default","password":""}]'
+      DEFAULT_SOURCES:
+        '[{"from":{"databaseName":"default","tableName":"otel_logs"},"kind":"log","timestampValueExpression":"TimestampTime","name":"Logs","displayedTimestampValueExpression":"Timestamp","implicitColumnExpression":"Body","serviceNameExpression":"ServiceName","bodyExpression":"Body","eventAttributesExpression":"LogAttributes","resourceAttributesExpression":"ResourceAttributes","defaultTableSelectExpression":"Timestamp,ServiceName,SeverityText,Body","severityTextExpression":"SeverityText","traceIdExpression":"TraceId","spanIdExpression":"SpanId","connection":"Local
+        ClickHouse","traceSourceId":"Traces","sessionSourceId":"Sessions","metricSourceId":"Metrics"},{"from":{"databaseName":"default","tableName":"otel_traces"},"kind":"trace","timestampValueExpression":"Timestamp","name":"Traces","displayedTimestampValueExpression":"Timestamp","implicitColumnExpression":"SpanName","serviceNameExpression":"ServiceName","bodyExpression":"SpanName","eventAttributesExpression":"SpanAttributes","resourceAttributesExpression":"ResourceAttributes","defaultTableSelectExpression":"Timestamp,ServiceName,StatusCode,round(Duration/1e6),SpanName","traceIdExpression":"TraceId","spanIdExpression":"SpanId","durationExpression":"Duration","durationPrecision":9,"parentSpanIdExpression":"ParentSpanId","spanNameExpression":"SpanName","spanKindExpression":"SpanKind","statusCodeExpression":"StatusCode","statusMessageExpression":"StatusMessage","connection":"Local
+        ClickHouse","logSourceId":"Logs","sessionSourceId":"Sessions","metricSourceId":"Metrics"},{"from":{"databaseName":"default","tableName":""},"kind":"metric","timestampValueExpression":"TimeUnix","name":"Metrics","resourceAttributesExpression":"ResourceAttributes","metricTables":{"gauge":"otel_metrics_gauge","histogram":"otel_metrics_histogram","sum":"otel_metrics_sum","_id":"682586a8b1f81924e628e808","id":"682586a8b1f81924e628e808"},"connection":"Local
+        ClickHouse","logSourceId":"Logs","traceSourceId":"Traces","sessionSourceId":"Sessions"},{"from":{"databaseName":"default","tableName":"hyperdx_sessions"},"kind":"session","timestampValueExpression":"TimestampTime","name":"Sessions","displayedTimestampValueExpression":"Timestamp","implicitColumnExpression":"Body","serviceNameExpression":"ServiceName","bodyExpression":"Body","eventAttributesExpression":"LogAttributes","resourceAttributesExpression":"ResourceAttributes","defaultTableSelectExpression":"Timestamp,ServiceName,SeverityText,Body","severityTextExpression":"SeverityText","traceIdExpression":"TraceId","spanIdExpression":"SpanId","connection":"Local
+        ClickHouse","logSourceId":"Logs","traceSourceId":"Traces","metricSourceId":"Metrics"}]'
+    networks:
+      - default
+    restart: always
+    depends_on:
+      - clickhouse
+      - mongodb
 
-  # # The OpenTelemetry collector for ClickHouse/HyperDX (ClickStack)
-  # otel-collector:
-  #   image: docker.hyperdx.io/hyperdx/hyperdx-otel-collector:2
-  #   env_file:
-  #     - .env
-  #   environment:
-  #     CLICKHOUSE_ENDPOINT: 'tcp://clickhouse:9000?dial_timeout=10s'
-  #     HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE: default
-  #     OPAMP_SERVER_URL: 'http://hyperdx:4320'
-  #   restart: always
-  #   networks:
-  #     - default
-  #   depends_on:
-  #     - clickhouse
-  #     - hyperdx
+  # The OpenTelemetry collector for ClickHouse/HyperDX (ClickStack)
+  otel-collector:
+    image: docker.hyperdx.io/hyperdx/hyperdx-otel-collector:2
+    env_file:
+      - .env
+    environment:
+      CLICKHOUSE_ENDPOINT: 'tcp://clickhouse:9000?dial_timeout=10s'
+      HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE: default
+      OPAMP_SERVER_URL: 'http://hyperdx:4320'
+    restart: always
+    networks:
+      - default
+    depends_on:
+      - clickhouse
+      - hyperdx


### PR DESCRIPTION
Fixes https://github.com/transitiverobotics/issues/issues/625.

Also upgrades ClickHouse to 25.7.