### PR TITLE
Logging and resource monitoring follow up

### DIFF
--- a/cloud/app/package-lock.json
+++ b/cloud/app/package-lock.json
@@ -52,6 +52,7 @@
         "yargs": "^17.3.1"
       },
       "devDependencies": {
+        "fancy-ansi": "^0.1.3",
         "multi-range-slider-react": "^2.0.7"
       }
     },
@@ -5293,6 +5294,16 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "engines": {
         "node": "> 0.1.90"
+      }
+    },
+    "node_modules/fancy-ansi": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/fancy-ansi/-/fancy-ansi-0.1.3.tgz",
+      "integrity": "sha512-tRQVTo5jjdSIiydqgzIIEZpKddzSsfGLsSVt6vWdjVm7fbvDTiQkyoPu6Z3dIPlAM4OZk0jP5jmTCX4G8WGgBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "escape-html": "^1.0.3"
       }
     },
     "node_modules/fast-json-stable-stringify": {

--- a/cloud/app/package.json
+++ b/cloud/app/package.json
@@ -68,6 +68,7 @@
     ]
   },
   "devDependencies": {
+    "fancy-ansi": "^0.1.3",
     "multi-range-slider-react": "^2.0.7"
   },
   "config": {

--- a/cloud/app/server/server.js
+++ b/cloud/app/server/server.js
@@ -466,6 +466,8 @@ class _robotAgent extends Capability {
       // publish error counts per package
       this.mqttSync.publish(`${this.prefix}/status/logs/errorCount/+`);
 
+      // #TODO: add a migration strategy for cloudSTatus and errorCount
+
       log.debug('resubscribing');
       this.data.subscribePathFlat(
         '/+orgId/+deviceId/@transitive-robotics/_robot-agent/+/status/runningPackages/+scope/+capName/+version',
@@ -525,12 +527,12 @@ class _robotAgent extends Capability {
         log.debug('ClickHouse integration enabled');
         this.telemetry = new TelemetryService();
         this.telemetry.init().then(async () => {
-          await this.telemetry.sendLogs({
+          await this.telemetry.sendLogs([{
             timestamp: Date.now(),
               module: log.name,
               level: 'DEBUG',
               message: 'Portal (re-)started'
-            }, {
+            }], {
               'service.name': 'portal',
             }
           );

--- a/cloud/app/server/server.js
+++ b/cloud/app/server/server.js
@@ -609,7 +609,7 @@ class _robotAgent extends Capability {
           const pkgPath = [...prefixPath, 'status', 'logs', 'errorCount',
             scope, name];
 
-          const newErrors = (_.filter(logLines, line => line.level == 'error')).length;
+          const newErrors = (_.filter(logs, line => line.level == 'error')).length;
           const currentErrorCount = this.mqttSync.data.get(pkgPath);
           if (!currentErrorCount || newErrors > 0) {
             this.mqttSync.data.update(pkgPath, (currentErrorCount || 0) + newErrors);

--- a/cloud/app/server/server.js
+++ b/cloud/app/server/server.js
@@ -466,8 +466,6 @@ class _robotAgent extends Capability {
       // publish error counts per package
       this.mqttSync.publish(`${this.prefix}/status/logs/errorCount/+`);
 
-      // #TODO: add a migration strategy for cloudSTatus and errorCount
-
       log.debug('resubscribing');
       this.data.subscribePathFlat(
         '/+orgId/+deviceId/@transitive-robotics/_robot-agent/+/status/runningPackages/+scope/+capName/+version',

--- a/cloud/app/src/utils/index.jsx
+++ b/cloud/app/src/utils/index.jsx
@@ -4,12 +4,16 @@ import React, {forwardRef} from 'react';
 export const ActionLink = forwardRef((props, ref) => {
   const {onClick, onContextMenu, disabled, children} = props;
 
-  const style = {};
+  const style = {
+    // verticalAlign: 'middle',
+    // padding: '12px',
+  };
   disabled && Object.assign(style, {
     opacity: '0.5'
   });
 
   return <a href={disabled ? null : '#'} ref={ref}
+    className='btn btn-link'
     style={style}
     onClick={(e) => {
       e.preventDefault();

--- a/cloud/app/web_components/resource-metrics.jsx
+++ b/cloud/app/web_components/resource-metrics.jsx
@@ -1,13 +1,5 @@
 import React from 'react';
 import { Sparklines, SparklinesLine, SparklinesReferenceLine } from 'react-sparklines';
-
-const _ = {
-  get: require('lodash/get'),
-  takeRight: require('lodash/takeRight'),
-  maxBy: require('lodash/maxBy'),
-  mean: require('lodash/mean'),
-};
-
 import { getLogger } from '@transitive-sdk/utils-web';
 
 const log = getLogger('resource-metrics');
@@ -21,124 +13,75 @@ const styles = {
     flexDirection: 'column',
     gap: '0.5em',
   },
-  metricRow: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '0.5em',
-    fontSize: '0.8em',
-  },
-  currentValue: {
-    fontSize: '0.75em',
-    fontWeight: 'bold',
-    padding: '2px 4px',
-    borderRadius: '3px',
-    minWidth: '60px',
-    textAlign: 'center',
-  },
-  cpuValue: {
-    color: '#3498db',
-    backgroundColor: 'rgba(52, 152, 219, 0.1)',
-  },
-  systemCpuValue: {
-    color: '#9b59b6',
-    backgroundColor: 'rgba(155, 89, 182, 0.1)',
-  },
-  systemMemoryValue: {
-    color: '#f39c12',
-    backgroundColor: 'rgba(243, 156, 18, 0.1)',
-  },
   noData: {
     fontSize: '0.8em',
     color: '#6c757d',
     fontStyle: 'italic',
     textAlign: 'center',
     padding: '1em',
-    backgroundColor: '#f8f9fa',
   },
-  // Sparklines:
-  referenceLine: {
-    strokeOpacity: 0.3,
-    strokeDasharray: '1,1'
-  }
 };
 
+
 /** Format number as percentage */
-const formatPercentage = (x) => `${x.toFixed(1)} %`;
+const formatPercentage = (x) => `${x.toFixed(1)}%`;
 
 /** Draw a Sparkline with the given data and color, applying our common style */
-const Chart = ({data, color}) =>
-  <div style={{
-    flex: 1,
-    maxWidth: '80px',
-    backgroundColor: `${color}40` // semi-transparent
-  }}>
-    <Sparklines data={data} height={20} width={80} margin={2} max={100} min={0}>
-      <SparklinesLine color={color} style={{ strokeWidth: 1.5 }} />
-      <SparklinesReferenceLine type="mean"
-        style={{ stroke: color, ...styles.referenceLine }} />
-    </Sparklines>
+const Chart = ({label, data, color}) =>
+  <div title={`${label} usage over the last minute`}
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: '0.5em',
+      fontSize: '0.8em',
+      color: color,
+      maxWidth: '15em',
+    }}>
+
+    <span style={{
+      fontSize: '0.75em',
+      fontWeight: 'bold',
+      padding: '2px 4px',
+      borderRadius: '3px',
+      textAlign: 'center',
+    }}>
+      {`${label}: ${formatPercentage(data.at(-1) || 0)}`}
+    </span><div style={{
+      margin: 0,
+      flex: 1,
+      maxWidth: '8em',
+      backgroundColor: `${color}40` // semi-transparent
+    }}>
+      <Sparklines data={data} height={20} width={80} margin={2} max={100} min={0}>
+        <SparklinesLine color={color} style={{ strokeWidth: 1.5 }} />
+        <SparklinesReferenceLine type="mean"
+          style={{
+            stroke: color,
+            strokeOpacity: 0.3,
+            strokeDasharray: '1,1'
+          }} />
+      </Sparklines>
+    </div>
   </div>;
 
 
 /** Component to display resource metrics for CPU and Memory usage */
-const ResourceMetrics = ({ metrics }) => {
-  if (!metrics || (!metrics.cpu && !metrics.memory)) {
-    return (
-      <div style={styles.noData}>
-        No metrics data available yet
-      </div>
-    );
-  }
+const ResourceMetrics = ({ metrics }) => metrics?.cpu ?
+  // show metric when available
+  <div style={styles.metricsContainer}>
+    <Chart label='CPU' data={metrics.cpu || []} color='#3498db'/>
+    {metrics.system && (
+      <F>
+        System:<br/>
+        <Chart label='CPU' data={metrics.system.cpu || []} color='#9b59b6' />
+        <Chart label='Memory' data={metrics.system.memory || []} color='#f39c12' />
+      </F>
+    )}
+  </div>
+  // else:
+  : <div style={styles.noData}>
+    No metrics data available yet
+  </div>;
 
-  const cpuData = metrics.cpu || [];
-  const memoryData = metrics.memory || [];
-
-  let systemCpuData, systemMemoryData;
-  const hasSystemMetrics = metrics.system;
-  // Extract system metrics if available (only for robot-agent)
-  if (hasSystemMetrics) {
-    systemCpuData = metrics.system.cpu || [];
-    systemMemoryData = metrics.system.memory || [];
-  }
-
-  const latestCpu = cpuData[cpuData.length - 1] || 0;
-  const latestSystemCpu = hasSystemMetrics ?
-    (systemCpuData[systemCpuData.length - 1] || 0) : 0;
-  const latestSystemMemory = hasSystemMetrics ?
-    (systemMemoryData[systemMemoryData.length - 1] || 0) : 0;
-
-  return (
-    <div style={styles.metricsContainer}>
-      <div style={styles.metricRow}>
-        <span style={{...styles.currentValue, ...styles.cpuValue}}>
-          {`CPU: ${formatPercentage(latestCpu)}`}
-        </span>
-
-        <Chart data={cpuData} color="#3498db" />
-      </div>
-
-
-      {hasSystemMetrics && (
-        <F>
-          <div style={styles.metricRow}>
-            <span style={{...styles.currentValue, ...styles.systemCpuValue}}>
-              {`System CPU: ${formatPercentage(latestSystemCpu)}`}
-            </span>
-
-            <Chart data={systemCpuData} color="#9b59b6" />
-          </div>
-
-          <div style={styles.metricRow}>
-            <span style={{...styles.currentValue, ...styles.systemMemoryValue}}>
-              {`System Memory: ${formatPercentage(latestSystemMemory)}`}
-            </span>
-
-            <Chart data={systemMemoryData} color="#f39c12" />
-          </div>
-        </F>
-      )}
-    </div>
-  );
-};
 
 export default ResourceMetrics;

--- a/cloud/app/web_components/resource-metrics.jsx
+++ b/cloud/app/web_components/resource-metrics.jsx
@@ -27,15 +27,6 @@ const styles = {
     gap: '0.5em',
     fontSize: '0.8em',
   },
-  metricLabel: {
-    fontWeight: '500',
-    minWidth: '50px',
-    color: '#495057',
-  },
-  inlineChart: {
-    flex: 1,
-    maxWidth: '120px',
-  },
   currentValue: {
     fontSize: '0.75em',
     fontWeight: 'bold',
@@ -44,18 +35,9 @@ const styles = {
     minWidth: '60px',
     textAlign: 'center',
   },
-  avgValue: {
-    fontSize: '0.7em',
-    color: '#6c757d',
-    minWidth: '60px',
-  },
   cpuValue: {
     color: '#3498db',
     backgroundColor: 'rgba(52, 152, 219, 0.1)',
-  },
-  memoryValue: {
-    color: '#e74c3c',
-    backgroundColor: 'rgba(231, 76, 60, 0.1)',
   },
   systemCpuValue: {
     color: '#9b59b6',
@@ -73,19 +55,30 @@ const styles = {
     padding: '1em',
     backgroundColor: '#f8f9fa',
   },
+  // Sparklines:
+  referenceLine: {
+    strokeOpacity: 0.3,
+    strokeDasharray: '1,1'
+  }
 };
 
-const formatBytes = (bytes) => {
-  if (bytes === 0) return '0 B';
-  const k = 1024;
-  const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
-};
+/** Format number as percentage */
+const formatPercentage = (x) => `${x.toFixed(1)} %`;
 
-const formatCpu = (cpu) => {
-  return `${cpu.toFixed(1)}%`;
-};
+/** Draw a Sparkline with the given data and color, applying our common style */
+const Chart = ({data, color}) =>
+  <div style={{
+    flex: 1,
+    maxWidth: '80px',
+    backgroundColor: `${color}40` // semi-transparent
+  }}>
+    <Sparklines data={data} height={20} width={80} margin={2} max={100} min={0}>
+      <SparklinesLine color={color} style={{ strokeWidth: 1.5 }} />
+      <SparklinesReferenceLine type="mean"
+        style={{ stroke: color, ...styles.referenceLine }} />
+    </Sparklines>
+  </div>;
+
 
 /** Component to display resource metrics for CPU and Memory usage */
 const ResourceMetrics = ({ metrics }) => {
@@ -99,7 +92,7 @@ const ResourceMetrics = ({ metrics }) => {
 
   const cpuData = metrics.cpu || [];
   const memoryData = metrics.memory || [];
-  
+
   let systemCpuData, systemMemoryData;
   const hasSystemMetrics = metrics.system;
   // Extract system metrics if available (only for robot-agent)
@@ -107,76 +100,40 @@ const ResourceMetrics = ({ metrics }) => {
     systemCpuData = metrics.system.cpu || [];
     systemMemoryData = metrics.system.memory || [];
   }
-  
-  // Calculate averages
-  const avgCpu = _.mean(cpuData);
-  const avgMemory = _.mean(memoryData);
-  const avgSystemCpu = hasSystemMetrics ? _.mean(systemCpuData) : 0;
-  const avgSystemMemory = hasSystemMetrics ? _.mean(systemMemoryData) : 0;
-  
+
   const latestCpu = cpuData[cpuData.length - 1] || 0;
-  const latestMemory = memoryData[memoryData.length - 1] || 0;
-  const latestSystemCpu = hasSystemMetrics ? (systemCpuData[systemCpuData.length - 1] || 0) : 0;
-  const latestSystemMemory = hasSystemMetrics ? (systemMemoryData[systemMemoryData.length - 1] || 0) : 0;
+  const latestSystemCpu = hasSystemMetrics ?
+    (systemCpuData[systemCpuData.length - 1] || 0) : 0;
+  const latestSystemMemory = hasSystemMetrics ?
+    (systemMemoryData[systemMemoryData.length - 1] || 0) : 0;
 
   return (
     <div style={styles.metricsContainer}>
       <div style={styles.metricRow}>
-        <span style={styles.metricLabel}>CPU:</span>
         <span style={{...styles.currentValue, ...styles.cpuValue}}>
-          {formatCpu(latestCpu)}
+          {`CPU: ${formatPercentage(latestCpu)}`}
         </span>
-        <div style={styles.inlineChart}>
-          <Sparklines data={cpuData} height={20} width={120} margin={2}>
-            <SparklinesLine color="#3498db" style={{ strokeWidth: 1.5 }} />
-            <SparklinesReferenceLine type="mean" style={{ stroke: '#3498db', strokeOpacity: 0.3, strokeDasharray: '1,1' }} />
-          </Sparklines>
-        </div>
-        <span style={styles.avgValue}>avg: {formatCpu(avgCpu)}</span>
+
+        <Chart data={cpuData} color="#3498db" />
       </div>
-      
-      <div style={styles.metricRow}>
-        <span style={styles.metricLabel}>Memory:</span>
-        <span style={{...styles.currentValue, ...styles.memoryValue}}>
-          {formatBytes(latestMemory)}
-        </span>
-        <div style={styles.inlineChart}>
-          <Sparklines data={memoryData} height={20} width={120} margin={2}>
-            <SparklinesLine color="#e74c3c" style={{ strokeWidth: 1.5 }} />
-            <SparklinesReferenceLine type="mean" style={{ stroke: '#e74c3c', strokeOpacity: 0.3, strokeDasharray: '1,1' }} />
-          </Sparklines>
-        </div>
-        <span style={styles.avgValue}>avg: {formatBytes(avgMemory)}</span>
-      </div>
-      
+
+
       {hasSystemMetrics && (
         <F>
           <div style={styles.metricRow}>
-            <span style={styles.metricLabel}>Sys CPU:</span>
             <span style={{...styles.currentValue, ...styles.systemCpuValue}}>
-              {formatCpu(latestSystemCpu)}
+              {`System CPU: ${formatPercentage(latestSystemCpu)}`}
             </span>
-            <div style={styles.inlineChart}>
-              <Sparklines data={systemCpuData} height={20} width={120} margin={2}>
-                <SparklinesLine color="#9b59b6" style={{ strokeWidth: 1.5 }} />
-                <SparklinesReferenceLine type="mean" style={{ stroke: '#9b59b6', strokeOpacity: 0.3, strokeDasharray: '1,1' }} />
-              </Sparklines>
-            </div>
-            <span style={styles.avgValue}>avg: {formatCpu(avgSystemCpu)}</span>
+
+            <Chart data={systemCpuData} color="#9b59b6" />
           </div>
-          
+
           <div style={styles.metricRow}>
-            <span style={styles.metricLabel}>Sys Mem:</span>
             <span style={{...styles.currentValue, ...styles.systemMemoryValue}}>
-              {formatBytes(latestSystemMemory)}
+              {`System Memory: ${formatPercentage(latestSystemMemory)}`}
             </span>
-            <div style={styles.inlineChart}>
-              <Sparklines data={systemMemoryData} height={20} width={120} margin={2}>
-                <SparklinesLine color="#f39c12" style={{ strokeWidth: 1.5 }} />
-                <SparklinesReferenceLine type="mean" style={{ stroke: '#f39c12', strokeOpacity: 0.3, strokeDasharray: '1,1' }} />
-              </Sparklines>
-            </div>
-            <span style={styles.avgValue}>avg: {formatBytes(avgSystemMemory)}</span>
+
+            <Chart data={systemMemoryData} color="#f39c12" />
           </div>
         </F>
       )}

--- a/cloud/app/web_components/resource-metrics.jsx
+++ b/cloud/app/web_components/resource-metrics.jsx
@@ -22,7 +22,7 @@ const ResourceMetrics = ({label, data, color, title}) => {
       fontSize: '0.7em',
       color: color,
       width: '12em',
-      marginRight: '0.5em'
+      marginRight: '1em'
     },
     chart: {
       margin: 0,

--- a/cloud/app/web_components/resource-metrics.jsx
+++ b/cloud/app/web_components/resource-metrics.jsx
@@ -7,81 +7,53 @@ log.setLevel('debug');
 
 const F = React.Fragment;
 
-const styles = {
-  metricsContainer: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '0.5em',
-  },
-  noData: {
-    fontSize: '0.8em',
-    color: '#6c757d',
-    fontStyle: 'italic',
-    textAlign: 'center',
-    padding: '1em',
-  },
-};
-
 
 /** Format number as percentage */
 const formatPercentage = (x) => `${x.toFixed(1)}%`;
 
 /** Draw a Sparkline with the given data and color, applying our common style */
-const Chart = ({label, data, color}) =>
-  <div title={`${label} usage over the last minute`}
-    style={{
-      display: 'flex',
+const ResourceMetrics = ({label, data, color, title}) => {
+
+  const styles = {
+    metricsContainer: {
+      display: 'inline-flex',
       alignItems: 'center',
       gap: '0.5em',
-      fontSize: '0.8em',
+      fontSize: '0.7em',
       color: color,
-      maxWidth: '15em',
-    }}>
-
-    <span style={{
-      fontSize: '0.75em',
-      fontWeight: 'bold',
-      padding: '2px 4px',
-      borderRadius: '3px',
-      textAlign: 'center',
-    }}>
-      {`${label}: ${formatPercentage(data.at(-1) || 0)}`}
-    </span><div style={{
+      width: '12em',
+      marginRight: '0.5em'
+    },
+    chart: {
       margin: 0,
       flex: 1,
       maxWidth: '8em',
-      backgroundColor: `${color}40` // semi-transparent
-    }}>
+      backgroundColor: `${color}20` // semi-transparent
+    },
+    referenceLine: {
+      stroke: color,
+      strokeOpacity: 0.3,
+      strokeDasharray: '1,1'
+    },
+  };
+
+
+  if (!data || data.length == 0) {
+    return null;
+  }
+
+  return <div title={`${title} over the last minute`} style={styles.metricsContainer}>
+    <span style={{ fontWeight: 'bold' }}>
+      {`${label}: ${formatPercentage(data.at(-1) || 0)}`}
+    </span>
+
+    <span style={styles.chart}>
       <Sparklines data={data} height={20} width={80} margin={2} max={100} min={0}>
         <SparklinesLine color={color} style={{ strokeWidth: 1.5 }} />
-        <SparklinesReferenceLine type="mean"
-          style={{
-            stroke: color,
-            strokeOpacity: 0.3,
-            strokeDasharray: '1,1'
-          }} />
+        <SparklinesReferenceLine type="mean" style={styles.referenceLine} />
       </Sparklines>
-    </div>
+    </span>
   </div>;
-
-
-/** Component to display resource metrics for CPU and Memory usage */
-const ResourceMetrics = ({ metrics }) => metrics?.cpu ?
-  // show metric when available
-  <div style={styles.metricsContainer}>
-    <Chart label='CPU' data={metrics.cpu || []} color='#3498db'/>
-    {metrics.system && (
-      <F>
-        System:<br/>
-        <Chart label='CPU' data={metrics.system.cpu || []} color='#9b59b6' />
-        <Chart label='Memory' data={metrics.system.memory || []} color='#f39c12' />
-      </F>
-    )}
-  </div>
-  // else:
-  : <div style={styles.noData}>
-    No metrics data available yet
-  </div>;
-
+};
 
 export default ResourceMetrics;

--- a/cloud/app/web_components/robot-agent-device-header.jsx
+++ b/cloud/app/web_components/robot-agent-device-header.jsx
@@ -46,8 +46,10 @@ const Device = (props) => {
   const [scope, capName] = pkg.split('/');
 
   useEffect(() => {
-    mqttSync?.subscribe(`${prefix}/+/#`);
-  }, [mqttSync]);
+      if (!mqttSync) return;
+      mqttSync.subscribe(`${prefix}/+/status/heartbeat`);
+      mqttSync.subscribe(`${prefix}/+/info/#`);
+    }, [mqttSync]);
 
   const ourData = data?.[id]?.[device]?.['@transitive-robotics']['_robot-agent'];
   const mergedData = mergeVersions(ourData);

--- a/cloud/app/web_components/robot-agent-device-header.jsx
+++ b/cloud/app/web_components/robot-agent-device-header.jsx
@@ -10,7 +10,7 @@ import { Badge, Button } from 'react-bootstrap';
 import { useMqttSync, createWebComponent, decodeJWT, mergeVersions, getLogger, versionCompare}
 from '@transitive-sdk/utils-web';
 
-import { Heartbeat, ensureProps, GetLogButtonWithCounter } from './shared';
+import { Heartbeat, ensureProps, LogButtonWithCounter } from './shared';
 
 const log = getLogger('robot-agent-device-header');
 log.setLevel('debug');
@@ -48,6 +48,7 @@ const Device = (props) => {
   useEffect(() => {
       if (!mqttSync) return;
       mqttSync.subscribe(`${prefix}/+/status/heartbeat`);
+      mqttSync.publish(`${prefix}/+/status/logs/errorCount/+`);
       mqttSync.subscribe(`${prefix}/+/info/#`);
     }, [mqttSync]);
 
@@ -65,12 +66,13 @@ const Device = (props) => {
     {mergedData?.info?.labels?.map(label =>
         <span key={label}>{' '}<Badge bg="info">{label}</Badge></span>)
     }
-    <GetLogButtonWithCounter
+    <LogButtonWithCounter
       text="show capability log"
       mqttSync={mqttSync}
       versionPrefix={versionPrefix}
       packageName={pkg}
-      toolTipPlacement='bottom'
+      // toolTipPlacement='bottom',
+      errorCount={mergedData?.status?.logs?.errorCount?.[scope]?.[capName]}
     />
   </div>;
 };

--- a/cloud/app/web_components/robot-agent-device.jsx
+++ b/cloud/app/web_components/robot-agent-device.jsx
@@ -200,7 +200,7 @@ const Package = ({pkg, install, issues}) => {
 const Capability = (props) => {
 
   const { mqttSync, running, desired, status, disabled, name, title,
-    inactive, device, versionPrefix, desiredPackagesTopic, canPay, 
+    inactive, device, versionPrefix, desiredPackagesTopic, canPay,
     deviceData, preInstalled
   } = props;
 
@@ -352,7 +352,17 @@ const Device = (props) => {
 
   useEffect(() => {
       if (mqttSync) {
-        mqttSync.subscribe(`${prefix}/+`); // TODO: narrow this
+        // mqttSync.subscribe(`${prefix}/+`); // TODO: narrow this
+        mqttSync.subscribe(`${prefix}/+/info/#`);
+        mqttSync.subscribe(`${prefix}/+/status/heartbeat`);
+        mqttSync.subscribe(`${prefix}/+/status/pong`);
+        mqttSync.subscribe(`${prefix}/+/status/package/#`);
+        mqttSync.subscribe(`${prefix}/+/status/runningPackages/#`);
+        mqttSync.subscribe(`${prefix}/+/status/selfCheckErrors/#`);
+        mqttSync.subscribe(`${prefix}/+/status/ready`);
+        mqttSync.subscribe(`${prefix}/+/desiredPackages/#`);
+        mqttSync.subscribe(`${prefix}/+/disabledPackages/#`);
+
         mqttSync.publish(`${prefix}/+/desiredPackages`, {atomic: true});
         mqttSync.publish(`${prefix}/+/disabledPackages`, {atomic: true});
         mqttSync.publish(`${prefix}/+/client/#`); // for client pings

--- a/cloud/app/web_components/robot-agent-device.jsx
+++ b/cloud/app/web_components/robot-agent-device.jsx
@@ -253,7 +253,10 @@ const Capability = (props) => {
         <Col sm='2' style={styles.rowItem}>
           {running && !inactive && (
             <ResourceMetrics
-              metrics={deviceData?.status?.metrics?.samplesPerPackage?.[name] || {}}
+              label='CPU'
+              title='CPU usage by this capability'
+              color='#3498db'
+              data={deviceData?.status?.metrics?.packages?.[name]}
             />
           )}
         </Col>
@@ -499,7 +502,23 @@ const Device = (props) => {
           packageName="robot-agent"
         />
 
-      <Fold title="Configuration & status">
+      <div>
+        <ResourceMetrics
+          label='CPU'
+          title='System: total CPU usage'
+          color='#9b59b6'
+          data={latestVersionData?.status?.metrics?.system.cpu}
+          />
+        <ResourceMetrics
+          label='Mem'
+          title='System: total (active) memory usage'
+          color='#f39c12'
+          data={latestVersionData?.status?.metrics?.system.mem}
+          />
+
+      </div>
+
+      <Fold title="Configuration">
           <F>
             <div style={styles.row}>
               {latestVersionData?.info?.config &&
@@ -507,12 +526,6 @@ const Device = (props) => {
                   updateConfig={
                     (modifier) => runCommand('updateConfig', {modifier}, log.debug)
                   }/>}
-            </div>
-            <div style={styles.row}>
-              <strong>Agent Resource Usage</strong>
-              <ResourceMetrics
-                metrics={latestVersionData?.status?.metrics?.samplesPerPackage?.['robot-agent'] || {}}
-              />
             </div>
           </F>
       </Fold>

--- a/cloud/app/web_components/robot-agent-device.jsx
+++ b/cloud/app/web_components/robot-agent-device.jsx
@@ -145,6 +145,7 @@ const OSInfo = ({info}) => !info ? <div></div> :
     </div>
     <Form.Text>
       {info.os.dpkgArch}, {info.os.lsb?.Description}
+      {info.isDocker && <span> (Docker)</span>}
       {info.geo && <span>, {info.geo.city}, {info.geo.country}</span>}
     </Form.Text>
   </div>;
@@ -228,7 +229,7 @@ const Capability = (props) => {
           <div>{title}</div>
           <div style={styles.subText}>{name}</div>
         </Col>
-        <Col sm='2' style={styles.rowItem}>
+        <Col sm='3' style={styles.rowItem}>
           { running && !inactive && <div><Badge bg="success"
                 title={Object.values(running).join(', ')}>
                 running: v{Object.keys(running).join(', ')}
@@ -249,14 +250,14 @@ const Capability = (props) => {
                 disabled</Badge></div>
           }
         </Col>
-        <Col sm='3' style={styles.rowItem}>
+        <Col sm='2' style={styles.rowItem}>
           {running && !inactive && (
             <ResourceMetrics
               metrics={deviceData?.status?.metrics?.samplesPerPackage?.[name] || {}}
             />
           )}
         </Col>
-        <Col sm='3' style={styles.rowItem}>
+        <Col sm='4' style={styles.rowItem}>
           {!inactive && <div style={{textAlign: 'right'}}>
             {
               running && <Button variant='link'
@@ -353,6 +354,10 @@ const Device = (props) => {
   useEffect(() => {
       if (mqttSync) {
         // mqttSync.subscribe(`${prefix}/+`); // TODO: narrow this
+        // Since the robot now publishes non-JSON data on /status/log/live, we
+        // need to make sure not to subscribe to that topic with MqttSync, to
+        // avoid trying to parse that data. See
+        // https://github.com/transitiverobotics/transitive-utils/commit/5205e0c
         mqttSync.subscribe(`${prefix}/+/info/#`);
         mqttSync.subscribe(`${prefix}/+/status/heartbeat`);
         mqttSync.subscribe(`${prefix}/+/status/pong`);

--- a/cloud/app/web_components/shared.jsx
+++ b/cloud/app/web_components/shared.jsx
@@ -161,6 +161,7 @@ export const PkgLog = ({response, mqttClient, agentPrefix, hide}) => {
     <Modal.Body>
       {stdout ? <pre style={style}>{stdout}</pre> : <div>stdout is empty</div>}
       <h5>Live Log:</h5>
+      (Configured <tt>minLogLevel</tt> (default: "error") and above only.)
       <pre style={style}>
         {liveLogs}
       </pre>

--- a/cloud/app/web_components/shared.jsx
+++ b/cloud/app/web_components/shared.jsx
@@ -161,7 +161,10 @@ export const PkgLog = ({response, mqttClient, agentPrefix, hide}) => {
     <Modal.Header closeButton>
       <Modal.Title>Log for {packageName}</Modal.Title>
     </Modal.Header>
-    <Modal.Body style={{background: 'hsl(240, 7%, 5%)'}}>
+    <Modal.Body style={{
+      background: 'hsl(240, 7%, 5%)',
+      color: '#eee',
+    }}>
       {/* {stdout ? <pre style={style}>{stdout}</pre> : <div>stdout is empty</div>} */}
       { lines ?
         lines.map((line, i) => <AnsiHtml style={style} text={line} key={i}/>)

--- a/cloud/docker-compose.override.yaml
+++ b/cloud/docker-compose.override.yaml
@@ -80,3 +80,7 @@ services:
 
   clickhouse:
     build: ./clickhouse
+    # only in dev: open some of the ports
+    ports:
+      - "8123:8123"  # HTTP interface for web UI and API
+      - "9002:9000"  # Native TCP interface for clients (mapped to avoid conflict

--- a/cloud/docker-compose.yaml
+++ b/cloud/docker-compose.yaml
@@ -203,7 +203,6 @@ services:
   # HyperDX
 
   clickhouse:
-    # image: clickhouse/clickhouse-server:24-alpine
     image: transitiverobotics/clickhouse:latest
     env_file:
       - .env
@@ -216,9 +215,6 @@ services:
     restart: always
     networks:
       - default
-    ports:
-      - "8123:8123"  # HTTP interface for web UI and API
-      - "9002:9000"  # Native TCP interface for clients (mapped to avoid conflict
     deploy:
       resources:
         limits:

--- a/cloud/sample.env
+++ b/cloud/sample.env
@@ -44,6 +44,12 @@ TR_BILLING_SECRET=#your_transitiverobotics.com_jwt_secret
 # foldername we are starting from.
 COMPOSE_PROJECT_NAME=cloud
 
+# URL for HyperDX behind proxy. Use https in production
+HYPERDX_APP_URL=http://hyperdx.your-domain.com
+
+# enables logs and metrics saving into clickhouse
+CLICKHOUSE_ENABLED=true
+
 ## --- Dev
 
 # In dev we want to start some auxiliary services in docker-compose. Set to prod
@@ -54,9 +60,3 @@ COMPOSE_PROFILES=dev
 # use the local one instead. Only use when developing @transitive-robotics
 # capabilities locally.
 # TR_REGISTRY_IS_LOCAL=true
-
-# URL for HyperDX behind proxy. Use https in production
-HYPERDX_APP_URL=http://hyperdx.your-domain.com
-
-# enables logs and metrics saving into clickhouse
-CLICKHOUSE_ENABLED=true

--- a/robot-agent/commands.js
+++ b/robot-agent/commands.js
@@ -46,11 +46,7 @@ const commands = {
 
   getPkgLog: ({pkg}) => {
     return new Promise((resolve, reject) => {
-      const logPath = (pkg === 'robot-agent') ?
-        '~/.transitive/agent.log' :
-        `~/.transitive/packages/${pkg}/log`;
-
-      exec(`cat ${logPath} | tail -n 100000`,
+      exec(`cat ~/.transitive/packages/${pkg}/log | tail -n 100000`,
         (err, stdout, stderr) => resolve({
           err,
           stdout: zlib.gzipSync(stdout).toString('base64'),

--- a/robot-agent/config.js
+++ b/robot-agent/config.js
@@ -1,7 +1,11 @@
 const fs = require('fs');
 const dotenv = require('dotenv');
-const { clone } = require('@transitive-sdk/utils');
+const _ = require('lodash');
+const { clone, getLogger } = require('@transitive-sdk/utils');
 const { getInstalledPackages, updatePackageConfigFile } = require('./utils');
+
+const log = getLogger('config.js');
+log.setLevel('info');
 
 dotenv.config({path: './.env'});
 dotenv.config({path: './.env_user'});
@@ -9,35 +13,40 @@ dotenv.config({path: './.env_user'});
 global.config = {};
 const fleetConfig = {};
 
-const refreshGlobalConfigFromFile = () => {
+const refreshGlobalConfigFromFile = _.debounce(() => {
+  log.info('Reloading config.json');
+
   try {
     global.config = JSON.parse(fs.readFileSync('./config.json', {encoding: 'utf8'}));
-    console.log(`Using config:\n${JSON.stringify(global.config, true, 2)}`);
+    log.info(`Using config: ${JSON.stringify(global.config)}`);
+
     const packages = getInstalledPackages();
     // generate config.json for each package
     packages.forEach(updatePackageConfigFile);
     // update the config in the fleet data store
     if (global.data) {
       // update the config in the fleet data store
-      console.log(`Updating global config in ${global.AGENT_PREFIX}/info/config`);
+      log.debug(`Updating global config in ${global.AGENT_PREFIX}/info/config`);
       global.data.update(`${global.AGENT_PREFIX}/info/config`, clone(global.config));
     }
   } catch (e) {
-    console.log('No config.json file found or not valid JSON, proceeding without.');
+    log.warn('No config.json file found or not valid JSON, proceeding without.');
   }
-};
+}, 100);
+
 refreshGlobalConfigFromFile();
 
 fs.watch('./', { persistence: false }, (eventType, filename) => {
   if (filename !== 'config.json') {
     return;
   }
-  // check if the file exists, eventType == 'rename' triggers when the file is created or deleted
-  // but we only want to reload if the file is changed or created
+  // check if the file exists, eventType == 'rename' triggers when the file is
+  // created or deleted but we only want to reload if the file is changed or
+  // created
   if (eventType == 'rename' && !fs.existsSync('./config.json')) {
     return;
   }
-  console.log('config.json changed, reloading...');
+
   refreshGlobalConfigFromFile();
 });
 

--- a/robot-agent/index.js
+++ b/robot-agent/index.js
@@ -31,7 +31,6 @@ if (!process.env.TR_USERID) {
 // --------------------------------------------------------------------------
 
 const {exec, execSync} = require('child_process');
-const { CronJob } = require('cron');
 const {restartPackage, startPackage, rotateAllLogs,
   upgradeNodejs, killAllPackages, getInstalledPackages
 } = require('./utils');
@@ -145,9 +144,10 @@ const update = () => {
 };
 
 setInterval(update, UPDATE_INTERVAL);
-// rotate all log files at 1am
-rotateAllLogs();
-new CronJob('0 0 1 * * *', rotateAllLogs, null, true);
+
+// rotateAllLogs();
+// rotate all log files once a day at 1am
+// new CronJob('0 0 1 * * *', rotateAllLogs, null, true);
 
 update();
 
@@ -162,3 +162,7 @@ process.on('uncaughtException', (err) => {
   console.error(`**** Caught exception: ${err}:`, err.stack);
 });
 
+
+// #DEBUG
+// setTimeout(() => log.error('error test'), 5000);
+// setTimeout(() => log.warn('warn test'), 5000);

--- a/robot-agent/index.js
+++ b/robot-agent/index.js
@@ -31,9 +31,8 @@ if (!process.env.TR_USERID) {
 // --------------------------------------------------------------------------
 
 const {exec, execSync} = require('child_process');
-const {restartPackage, startPackage, rotateAllLogs,
-  upgradeNodejs, killAllPackages, getInstalledPackages
-} = require('./utils');
+const {restartPackage, startPackage, upgradeNodejs, killAllPackages,
+  getInstalledPackages } = require('./utils');
 const { getLogger } = require('@transitive-sdk/utils');
 const localApi = require('./localApi');
 
@@ -145,10 +144,6 @@ const update = () => {
 
 setInterval(update, UPDATE_INTERVAL);
 
-// rotateAllLogs();
-// rotate all log files once a day at 1am
-// new CronJob('0 0 1 * * *', rotateAllLogs, null, true);
-
 update();
 
 // TODO: make this safer against self-destructing updates by only loading this
@@ -161,8 +156,3 @@ localApi.startServer();
 process.on('uncaughtException', (err) => {
   console.error(`**** Caught exception: ${err}:`, err.stack);
 });
-
-
-// #DEBUG
-// setTimeout(() => log.error('error test'), 5000);
-// setTimeout(() => log.warn('warn test'), 5000);

--- a/robot-agent/localMQTT.js
+++ b/robot-agent/localMQTT.js
@@ -39,8 +39,9 @@ const tryJSONParse = (string) => {
 const ensureSlash = (topic) => `${(topic[0] == '/' ? '' : '/')}${topic}`;
 
 /** Start the local mqtt broker. upstreamClient is the upstream mqtt client */
-const startLocalMQTTBroker = (upstreamClient, mqttSync, prefix, agentPrefix, onError) => {
+const startLocalMQTTBroker = (mqttSync, prefix, agentPrefix, onError) => {
 
+  const upstreamClient = mqttSync.mqtt;
   const aedes = Aedes({persistence});
 
   const server = require('net').createServer(aedes.handle);
@@ -88,7 +89,7 @@ const startLocalMQTTBroker = (upstreamClient, mqttSync, prefix, agentPrefix, onE
     log.info('clientReady', client.id, client.meta);
     const path = [agentPrefix, 'status', 'runningPackages', client.id ];
     const version = client.meta?.version || client.id.split('/').at(-1);
-    mqttSync.data.update(path.join('/'), version); 
+    mqttSync.data.update(path.join('/'), version);
   });
 
   aedes.on('clientDisconnect', (client) => {

--- a/robot-agent/logMonitor.js
+++ b/robot-agent/logMonitor.js
@@ -69,6 +69,7 @@ class LogMonitor {
     ) || 0; // Get last log timestamp or default to 0
 
     this.rotateLogs();
+    // rotate all log files once a day at 1am
     new CronJob('0 0 1 * * *', this.rotateLogs.bind(this), null, true);
 
     this.watchLogs('@transitive-robotics/robot-agent');
@@ -260,6 +261,8 @@ class LogMonitor {
    * Retries failed uploads and updates the last log timestamp.
    */
   async uploadPendingLogs() {
+
+    if (this.pendingLogs.length == 0) return; // nothing to do
     if (this.uploading) return; // already running
     this.uploading = true;
 

--- a/robot-agent/logMonitor.js
+++ b/robot-agent/logMonitor.js
@@ -4,35 +4,38 @@ const zlib = require('zlib');
 
 const { Tail } = require('tail');
 const _ = require('lodash');
+const { CronJob } = require('cron');
 
 const { getLogger, wait } = require('@transitive-sdk/utils');
-const log = getLogger('logMonitor.js');
-log.setLevel('info');
 
-const WAIT_TIME_IN_CASE_OF_ERROR = 5000; // 5 seconds
+const utils = require('./utils');
+
+const log = getLogger('logMonitor.js');
+log.setLevel('debug');
+
+const WAIT_BETWEEN_BATCHES = 10000; // time to wait between sending batches of logs
+const WAIT_TIME_IN_CASE_OF_ERROR = 5000; // Retry after this many ms after an error
 const MAX_LOGS_PER_BATCH = 500; // Maximum number of logs to upload in one go
 
-const getSeverityNumber = (level) => {
+const getSeverityNumber = (level, defaultLevel = 'error') => {
   const levelMap = {
-    'UNSPECIFIED': 0,
-    'TRACE': 1,
-    'DEBUG': 5,
-    'INFO': 9,
-    'WARN': 13,
-    'ERROR': 17,
-    'FATAL': 21
+    'unspecified': 0,
+    'trace': 1,
+    'debug': 5,
+    'info': 9,
+    'warn': 13,
+    'error': 17,
+    'fatal': 21
   };
-  return levelMap[level] || levelMap['UNSPECIFIED'];
-}
-
+  return levelMap[level.toLowerCase()] || levelMap[defaultLevel];
+};
 
 /** Get the currently configured level of logging for the given package name
  * or the global one if not specified. Defaults to 'ERROR' if not set. */
 const getMinLogLevel = (packageName) => {
-  const globalMinLogLevel = _.get(global.config, 'global.minLogLevel', 'ERROR');
-  return (packageName === 'robot-agent' ? globalMinLogLevel
-    : _.get(global.config, `${packageName}.minLogLevel`, globalMinLogLevel)
-  );
+  const globalMinLogLevel = _.get(global.config, 'global.minLogLevel', 'error');
+  return _.get(global.config, `${packageName}.minLogLevel`, globalMinLogLevel)
+    .toLowerCase();
 };
 
 /** LogMonitor handles log monitoring and uploading.
@@ -45,59 +48,52 @@ class LogMonitor {
   uploading = false; /// whether or not we are currently uploading pending logs
 
   constructor() {
-    this.mqttClient = null;
     this.mqttSync = null;
     this.AGENT_PREFIX = null;
     this.watchedPackages = {}; // Store watched packages and data
     this.pendingLogs = []; // Array to store pending logs
-    this.initialized = false;
-    this.uploadNextLogsTimer = null;
     this.lastLogTimestamp = 0; // Timestamp of the last log sent
   }
 
   /**
    * Initializes the LogMonitor instance.
-   * @param {Object} mqttClient - MQTT client instance for publishing logs.
    * @param {Object} mqttSync - MQTT sync object to listen for log level changes.
    * @param {string} agentPrefix - Topic prefix for logs publishing.
    */
-  init(mqttClient, mqttSync, agentPrefix){
-    this.mqttClient = mqttClient;
+  init(mqttSync, agentPrefix){
     this.mqttSync = mqttSync;
     this.AGENT_PREFIX = agentPrefix;
 
-    this.mqttSync.data.subscribePathFlat(`${this.AGENT_PREFIX}/info/config`, () => {
+    this.lastLogTimestamp = this.mqttSync.data.getByTopic(
+      `${this.AGENT_PREFIX}/cloudStatus/lastLogTimestamp`
+    ) || 0; // Get last log timestamp or default to 0
+
+    this.rotateLogs();
+    new CronJob('0 0 1 * * *', this.rotateLogs.bind(this), null, true);
+
+    this.watchLogs('@transitive-robotics/robot-agent');
+
+    this.mqttSync.data.subscribePath(`${this.AGENT_PREFIX}/info/config`, () => {
       // Update minLogLevel for all watched packages
-      Object.keys(this.watchedPackages).forEach(packageName => {
+      _.forEach(this.watchedPackages, (pkgData, packageName) => {
         const minLogLevel = getMinLogLevel(packageName);
-        if (this.watchedPackages[packageName].minLogLevel === minLogLevel)
-          return; // No change in minLogLevel
-        log.info('Updating minLogLevel for', packageName, 'from',
-          this.watchedPackages[packageName].minLogLevel,
-          'to', minLogLevel
-        );
-        this.watchedPackages[packageName].minLogLevel = minLogLevel;
-        this.watchedPackages[packageName].minLogLevelValue = getSeverityNumber(minLogLevel);
+        pkgData.minLogLevelValue = getSeverityNumber(minLogLevel);
+        log.info(`Setting minLogLevel for ${packageName} to ${minLogLevel} (${
+          pkgData.minLogLevelValue})`);
       });
     });
+  }
 
-    this.mqttSync.waitForHeartbeatOnce(() => {
-      log.info('LogMonitor heartbeat received, initializing...');
-      this.lastLogTimestamp = this.mqttSync.data.getByTopic(
-        `${this.AGENT_PREFIX}/status/logs/lastLogTimestamp`
-      ) || 0; // Get last log timestamp or default to 0
-
-      this.initialized = true; // Set initialized state
-
-      log.info('Starting watching logs for packages registered before initialization');
-
-      _.forEach(this.watchedPackages, (packageData, packageName) => {
-        if (!packageData.initialized) {
-          this.watchLogs(packageName); // Start watching logs for the package
-        }
-      });
-
-      this.uploadPendingLogs(); // Start the log uploading process
+  /** Publish the given message in the given MQTT topic directly using QoS2,
+  * bypassing MqttSync. Returns a promise.
+  */
+  mqttPublishQos2Promise(topic, message) {
+    return new Promise((resolve, reject) => {
+      this.mqttSync.mqtt.publish(topic, message, { qos: 2 },
+        (err) => {
+          err && log.warn(`Failed to publish to ${topic}`, err);
+          resolve();
+        });
     });
   }
 
@@ -108,6 +104,7 @@ class LogMonitor {
    */
   watchLogs(packageName) {
     const watchedPackage = this.watchedPackages[packageName];
+
     if (watchedPackage) {
       if (watchedPackage.initialized) {
         log.info('Package is already being watched:', packageName);
@@ -119,51 +116,43 @@ class LogMonitor {
         initialized: false,
       }
     }
-    if (!this.initialized) {
-      log.debug('LogMonitor not initialized yet, package will be watched when ready:', packageName);
-      return;
-    }
 
-    this.clearErrors(packageName);
-    const filePath = (packageName === 'robot-agent') ?
-      `${process.env.HOME}/.transitive/agent.log` :
-      `${process.env.HOME}/.transitive/packages/${packageName}/log`;
+    // this.clearErrors(packageName);
+    // const filePath = `${process.env.HOME}/.transitive/packages/${packageName}/log`;
+    const filePath = `packages/${packageName}/log`;
 
     if (!fs.existsSync(filePath)) {
-      // log.warn(`Log file does not exist yet for package: ${packageName} at path: ${filePath}`);
-      // Retry watching logs after a delay
-      // setTimeout(() => this.watchLogs(packageName), 5000);
-      // log.debug('Waiting for log file to be created:', filePath);
       log.warn(`Log file ${filePath} for package ${packageName} does not exist`);
+      // this can happen in dev
       return;
     }
 
     const minLogLevel = getMinLogLevel(packageName);
     const minLogLevelValue = getSeverityNumber(minLogLevel);
-    this.watchedPackages[packageName].minLogLevel = minLogLevel;
     this.watchedPackages[packageName].minLogLevelValue = minLogLevelValue;
 
     log.debug('Watching logs for package:', packageName, 'at path:', filePath,
       ' with: ', { filePath, minLogLevel, minLogLevelValue }
     );
 
+    // First: read file on disk and ingest current lines newer than last sent
     const fileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
     const lines = fileContent.split('\n');
+
     for (const line of lines) {
       const logObject = this.parseLogLine(line, packageName);
       if (!logObject) continue; // skip lines that are not valid log lines
-      const { timestamp, level } = logObject;
-      this.updateErrors(packageName, logObject);
-      // Convert timestamp to milliseconds
-      if (timestamp < this.lastLogTimestamp) {
+      if (logObject.timestamp < this.lastLogTimestamp) {
         continue; // skip logs older than the last sent log
       }
       this.pendingLogs.push(logObject);
     }
 
     this.watchedPackages[packageName].initialized = true; // Mark as initialized
-
     this.uploadPendingLogs(); // Start the log uploading process
+
+
+    // Second: watch (tail) the file for new lines and ingest those
     const tail = new Tail(filePath);
     this.watchedPackages[packageName].tail = tail;
 
@@ -171,7 +160,6 @@ class LogMonitor {
       const logObject = this.parseLogLine(line, packageName);
       // skip lines that are not valid log lines or below the min level:
       if (!logObject) return;
-      this.updateErrors(packageName, logObject);
       this.pendingLogs.push(logObject);
       this.uploadPendingLogs(); // Start uploading process if it's not already running
     });
@@ -200,12 +188,14 @@ class LogMonitor {
       log.warn('Package is not being watched:', packageName);
       return; // Not watching this package
     }
+
     if (watchedPackage.tail) {
       watchedPackage.tail.unwatch(); // Stop tailing the log file
       log.info('Stopped watching logs for package:', packageName);
     } else {
       log.warn('No tail instance found for package:', packageName);
     }
+
     delete this.watchedPackages[packageName]; // Remove from watched packages
   }
 
@@ -247,8 +237,9 @@ class LogMonitor {
       log.warn('Invalid timestamp in log line:', dateTime, 'in line:', line);
       return null; // Skip invalid timestamps
     }
-    const upperLevel = level.toUpperCase();
-    const logLevelValue = getSeverityNumber(upperLevel);
+
+    const levelLower = level.toLowerCase();
+    const logLevelValue = getSeverityNumber(levelLower, 'unspecified');
     const minLogLevelValue = this.watchedPackages[packageName].minLogLevelValue;
 
     // Skip logs below the minimum log level
@@ -256,36 +247,13 @@ class LogMonitor {
     const logObject = {
       timestamp,
       module: moduleName,
-      level: upperLevel,
+      level: levelLower,
       logLevelValue,
       message,
       package: packageName
     };
     return logObject;
   }
-
-  // /**
-  //  * Starts the log uploading process if not already running.
-  //  */
-  // startUploadingLogs(delay = 0) {
-  //   if (!this.uploadNextLogsTimer) {
-  //     log.debug('Starting log upload process in', delay, 'ms');
-  //     this.uploadNextLogsTimer = setTimeout(async () => {
-  //       await this.uploadPendingLogs();
-  //     }, delay);
-  //   }
-  // }
-
-  // /**
-  //  * Clears the log upload timer if it exists.
-  //  */
-  // clearUploadLogsTimer() {
-  //   if (this.uploadNextLogsTimer) {
-  //     clearTimeout(this.uploadNextLogsTimer);
-  //     this.uploadNextLogsTimer = null;
-  //     log.debug('Cleared log upload timer');
-  //   }
-  // }
 
   /**
    * Uploads the next pending logs to the cloud.
@@ -295,45 +263,40 @@ class LogMonitor {
     if (this.uploading) return; // already running
     this.uploading = true;
 
-    if (!this.initialized) {
-      log.debug('LogMonitor not initialized yet, waiting...');
+    let logCount = 0;
+    log.debug('Starting to upload pending logs, count:', this.pendingLogs.length);
 
-    } else {
+    while (this.pendingLogs.length > 0) {
+      const logsToUpload = this.pendingLogs.slice(0, MAX_LOGS_PER_BATCH);
+      this.pendingLogs = this.pendingLogs.slice(MAX_LOGS_PER_BATCH);
 
-      let logCount = 0;
-      log.debug('Starting to upload pending logs, count:', this.pendingLogs.length);
+      try {
+        await this.publishLogsAsJson(logsToUpload);
+        // log.debug('Published logs:', logsToUpload);
+        logCount += logsToUpload.length;
 
-      while (this.pendingLogs.length > 0) {
-        const logsToUpload = this.pendingLogs.slice(0, MAX_LOGS_PER_BATCH);
-        this.pendingLogs = this.pendingLogs.slice(MAX_LOGS_PER_BATCH);
+      } catch (err) {
+        log.debug(`Failed to publish ${logsToUpload.length} logs:`, err.message);
+        log.debug(`Will retry uploading this logs in ${WAIT_TIME_IN_CASE_OF_ERROR} ms`);
+        // If an error occurs, we want to retry processing this log after a delay
+        // Re-add the log to the front of the queue:
+        this.pendingLogs = logsToUpload.concat(this.pendingLogs);
 
-        try {
-          await this.publishLogsAsJson(logsToUpload);
-          this.mqttSync.data.update(`${this.AGENT_PREFIX}/status/logs/lastLogTimestamp`,
-            logsToUpload[logsToUpload.length - 1].timestamp);
-          log.debug('Published logs:', logsToUpload);
-          logCount += logsToUpload.length;
-
-        } catch (err) {
-          log.debug(`Failed to publish ${logsToUpload.length} logs:`, err.message);
-          log.debug(`Will retry uploading this logs in ${WAIT_TIME_IN_CASE_OF_ERROR} ms`);
-          // If an error occurs, we want to retry processing this log after a delay
-          // Re-add the log to the front of the queue:
-          this.pendingLogs = logsToUpload.concat(this.pendingLogs);
-
-          setTimeout(() => this.uploadPendingLogs(), WAIT_TIME_IN_CASE_OF_ERROR);
-          this.uploading = false;
-          return;
-        }
+        setTimeout(() => this.uploadPendingLogs(), WAIT_TIME_IN_CASE_OF_ERROR);
+        this.uploading = false;
+        return;
       }
-      log.debug('Uploaded', logCount, 'logs successfully.');
     }
+    log.debug('Uploaded', logCount, 'logs successfully.');
 
     // now wait before releasing the `uploading` token, to ensure we don't upload
     // logs more than so often in regular operation
-    await wait(10000);
-
+    await wait(WAIT_BETWEEN_BATCHES);
     this.uploading = false;
+
+    // if during the wait more logs arrived, call us back:
+    if (this.pendingLogs.length > 0) this.uploadPendingLogs();
+    // #TODO: use _.debounce on uploadPendingLogs instead
   }
 
   /**
@@ -341,49 +304,20 @@ class LogMonitor {
    * @param {Array} logs - Array of log objects to publish.
    * @returns {Promise} - Resolves when the log is published.
    */
-  async publishLogsAsJson(logs){
+  async publishLogsAsJson(logs) {
     // const strMsg = JSON.stringify(logs);
     const zipMsg = zlib.gzipSync(JSON.stringify(logs));
 
-    return new Promise((resolve, reject) => {
-      this.mqttClient.publish(`${this.AGENT_PREFIX}/status/logs/live`, zipMsg,
-        { qos: 2 }, (err) => { if (err) reject(err); else resolve(); });
-    });
+    await this.mqttPublishQos2Promise(`${this.AGENT_PREFIX}/status/logs/live`, zipMsg);
   }
 
-  /** Clears the error logs count for a specific package.
-   * Also resets the last error log object for that package.
-   * @param {string} packageName - Name of the package to clear error logs count for.
-   */
-  clearErrors(packageName) {
-    if (!this.initialized) {
-      log.warn('LogMonitor not initialized, cannot clear error logs count for', packageName);
-      return;
-    }
-    this.mqttSync.data.update(`${this.AGENT_PREFIX}/status/logs/errorCount/${packageName}`, 0);
-    this.mqttSync.data.update(`${this.AGENT_PREFIX}/status/logs/lastError/${packageName}`, null);
-    // log.debug('Cleared error logs count for package:', packageName);
-  }
-
-  /** Increments the error logs count for a specific package.
-   * Also updates the last error log object for that package.
-   * @param {Object} errorLogObject - The error log object to store as the last error.
-   * @param {string} packageName - Name of the package to increment error logs count for.
-   */
-  updateErrors(packageName, errorLogObject) {
-    if (!this.initialized) {
-      log.warn('LogMonitor not initialized, cannot increment error logs count for', packageName);
-      return;
-    }
-    if (!errorLogObject || errorLogObject.level !== 'ERROR') {
-      return; // Only increment for error logs
-    }
-    const countTopic = `${this.AGENT_PREFIX}/status/logs/errorCount/${packageName}`;
-    const currentCount = this.mqttSync.data.getByTopic(countTopic) || 0;
-    this.mqttSync.data.update(countTopic, currentCount + 1);
-    this.mqttSync.data.update(
-      `${this.AGENT_PREFIX}/status/logs/lastError/${packageName}`, errorLogObject);
-    log.debug('Incremented error logs count for package:', packageName, 'to', currentCount + 1);
+  /** Rotate logs and indicate to cloud to clear error log counts */
+  rotateLogs() {
+    // Signal the cloud that we've rotated the logs and the error count should be
+    // reset to 0 for all packages.
+    log.debug('rotating logs');
+    utils.rotateAllLogs();
+    this.mqttPublishQos2Promise(`${this.AGENT_PREFIX}/status/logs/reset`, null);
   }
 }
 

--- a/robot-agent/logMonitor.js
+++ b/robot-agent/logMonitor.js
@@ -133,7 +133,8 @@ class LogMonitor {
     this.watchedPackages[packageName].minLogLevelValue = minLogLevelValue;
 
     log.debug('Watching logs for package:', packageName, 'at path:', filePath,
-      ' with: ', { filePath, minLogLevel, minLogLevelValue }
+      ' with: ', { filePath, minLogLevel, minLogLevelValue }, 'since',
+      this.lastLogTimestamp
     );
 
     // First: read file on disk and ingest current lines newer than last sent

--- a/robot-agent/mqtt.js
+++ b/robot-agent/mqtt.js
@@ -219,12 +219,7 @@ mqttClient.on('connect', function(connackPacket) {
         log.error('Failed to initialize log monitor:', err);
       }
 
-      try {
-        resourceMonitor.init(mqttSync, `${AGENT_PREFIX}/status/metrics`);
-        resourceMonitor.startMonitoring('robot-agent', process.pid);
-      } catch (err) {
-        log.error('Failed to initialize resource monitor:', err);
-      }
+      resourceMonitor.init(mqttSync, `${AGENT_PREFIX}/status/metrics`);
 
       initialized = true;
     });

--- a/robot-agent/package-lock.json
+++ b/robot-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@transitive-robotics/robot-agent",
-  "version": "2.4.0",
+  "version": "2.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@transitive-robotics/robot-agent",
-      "version": "2.4.0",
+      "version": "2.4.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/robot-agent/package.json
+++ b/robot-agent/package.json
@@ -7,8 +7,9 @@
     "test": "mocha -w *.test.js",
     "postinstall": "sh postinstall.sh",
     "preuninstall": "sh preuninstall.sh",
-    "dev": "DIR=$PWD; (cd ~/.transitive && env TR_DEVMODE=TRUE PATH=$PATH:~/.transitive/usr/sbin:~/.transitive/usr/bin:~/.transitive/sbin:~/.transitive/bin node $DIR/index.js 2>&1 | tee -a $HOME/.transitive/agent.log)",
-    "start": "DIR=$PWD; (cd ~/.transitive && ~/.transitive/usr/bin/node $DIR/index.js)"
+    "dev": "env TR_DEVMODE=TRUE PATH=$PATH:~/.transitive/usr/sbin:~/.transitive/usr/bin:~/.transitive/sbin:~/.transitive/bin npm run start",
+    "prestart": "mkdir -p ~/.transitive/packages/@transitive-robotics/robot-agent || true",
+    "start": "DIR=$PWD; (cd ~/.transitive && ~/.transitive/usr/bin/node $DIR/index.js  2>&1 | tee -a packages/@transitive-robotics/robot-agent/log)"
   },
   "keywords": [],
   "author": "Christian Fritz",

--- a/robot-agent/package.json
+++ b/robot-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitive-robotics/robot-agent",
-  "version": "2.4.0",
+  "version": "2.4.4",
   "description": "The Transitive Robotics robot agent, responsible for installing and starting capability packages on the device and relaying mqtt communication.",
   "main": "index.js",
   "scripts": {

--- a/robot-agent/resourceMonitor.js
+++ b/robot-agent/resourceMonitor.js
@@ -7,121 +7,134 @@ const { getLogger } = require('@transitive-sdk/utils');
 const log = getLogger('resourceMonitor');
 log.setLevel('info');
 
-const SAMPLE_RATE = 5000; // Sample every 5 seconds
-const SAMPLES_PER_BATCH = 12; // Publish metrics every 60 seconds
+const SAMPLE_RATE = 5000; // Sample every X ms
+const SAMPLES_PER_BATCH = 12; // Publish metrics once we have X samples
 
 
 /** CPU and Memory monitoring class with subprocess tracking */
 class ResourceMonitor {
-  constructor() {
-    this.mqttSync = null;
-    this.agentPrefix = null;
-    this.initialized = false;
-    this.monitoredPackages = {};
-    this.sampleTimestamps = [];
-  }
 
-  init(mqttSync, agentPrefix) {
+  mqttSync = null;
+  metricsTopic = null;
+  initialized = false;
+  monitoredPackages = {};
+  sampleTimestamps = [];
+
+  init(mqttSync, metricsTopic) {
     this.mqttSync = mqttSync;
-    this.agentPrefix = agentPrefix;
+    this.metricsTopic = metricsTopic;
+
     log.info('Starting resource monitoring for all monitored packages');
-    
+
     this.mqttSync.waitForHeartbeatOnce(() => {
-      log.info('ResourceMonitor heartbeat received, initializing...');      
+      log.info('ResourceMonitor heartbeat received, initializing...');
       this.initialized = true; // Set initialized state
     });
 
     // Start the periodic sampling and publishing of resource usage metrics
-    setInterval(async () => {
-      this.sampleTimestamps.push(Date.now());
-      _.forEach(this.monitoredPackages, async (pkgData, pkgName) => {    
-        const {pid} = pkgData; 
-        try {
-          if (pkgName === 'robot-agent') {
-            // For the robot-agent, we use pidusage directly
-            const stats = await pidusage(pid);
-
-            // Sample system metrics when monitoring robot-agent
-            const [systemCpuLoad, systemMemInfo] = await Promise.all([
-              si.currentLoad(),
-              si.mem()
-            ]);
-            pkgData.samples.push({
-              cpu: Number(stats.cpu.toPrecision(3)), // CPU usage percentage (3 significant digits)
-              memory: stats.memory, // Memory usage in bytes
-              system: {
-                cpu: Number(systemCpuLoad.currentLoad.toPrecision(3)), // Overall CPU usage percentage (3 significant digits)
-                memory: systemMemInfo.used
-              }
-            });
-          } else {
-            // For other packages, we use pidusage-tree to include subprocesses
-            const stats = await pidusageTree(pid); 
-
-            const nonNullStats = _.filter(stats, stat => stat !== null && stat !== undefined);
-    
-            pkgData.samples.push({
-              cpu: Number(
-                _.reduce(nonNullStats, (sum, stat) => sum + (stat ? stat.cpu : 0), 0)
-                .toPrecision(3)
-              ), // CPU usage percentage (aggregated)
-              memory: _.reduce(nonNullStats, (sum, stat) => sum + (stat ? stat.memory : 0), 0), // Memory usage in bytes (aggregated)
-            });
-          }
-        } catch (err) {
-          log.warn(`Failed to get resource usage for ${pkgName} (PID: ${pid}):`);
-          return;
-        }
-      });
-      // If first package has enough samples, publish all
-      const firstPkg = Object.keys(this.monitoredPackages)[0];
-      if (this.initialized) {
-        if (this.monitoredPackages[firstPkg]?.samples.length >= SAMPLES_PER_BATCH) {
-          const dataToSend = {
-            timestamps: this.sampleTimestamps.slice(-SAMPLES_PER_BATCH),
-            samplesPerPackage: {}
-          };
-          _.map(this.monitoredPackages, (pkgData, pkgName) => {
-            pkgData.samples = pkgData.samples.slice(-SAMPLES_PER_BATCH);
-            // complete samples with 0 on the left side if needed
-            while (pkgData.samples.length < SAMPLES_PER_BATCH) {
-              pkgData.samples.unshift({
-                cpu: 0,
-                memory: 0,
-                system: pkgName === 'robot-agent' ? { cpu: 0, memory: 0 } : undefined
-              });
-            }
-            
-            // Convert to new schema format: separate arrays for cpu and memory
-            const cpuSamples = pkgData.samples.map(sample => sample.cpu);
-            const memorySamples = pkgData.samples.map(sample => sample.memory);
-            
-            dataToSend.samplesPerPackage[pkgName] = {
-              cpu: cpuSamples,
-              memory: memorySamples
-            };
-            
-            // Add system metrics for robot-agent
-            if (pkgName === 'robot-agent') {
-              dataToSend.samplesPerPackage[pkgName].system = {
-                cpu: pkgData.samples.map(sample => sample.system?.cpu || 0),
-                memory: pkgData.samples.map(sample => sample.system?.memory || 0)
-              };
-            }
-          });
-          this.mqttSync.data.update(
-            `${this.agentPrefix}/status/metrics`,
-            dataToSend
-          );
-          // Clear samples after publishing
-          _.forEach(this.monitoredPackages, pkgData => {
-            pkgData.samples = [];
-          });
-        }
-      }
-    }, SAMPLE_RATE);
+    setInterval(this.collectAndPublish.bind(this), SAMPLE_RATE);
   }
 
+  /** Do one pass of collecting the metrics and adding them to mqttsync. */
+  async collectAndPublish() {
+
+    this.sampleTimestamps.push(Date.now());
+
+    await Promise.all(_.map(this.monitoredPackages, async (pkgData, pkgName) => {
+      const {pid} = pkgData;
+      try {
+        if (pkgName === 'robot-agent') {
+          // For the robot-agent, we use pidusage directly
+          const stats = await pidusage(pid);
+
+          // Sample system metrics when monitoring robot-agent
+          const [systemCpuLoad, systemMemInfo] =
+            await Promise.all([ si.currentLoad(), si.mem() ]);
+          log.debug({systemMemInfo});
+
+          pkgData.samples.push({
+            // CPU usage percentage
+            cpu: Number(stats.cpu.toPrecision(3)),
+            // memory: stats.memory, // Memory usage in bytes
+            system: {
+              // Overall CPU usage percentage
+              cpu: Number(systemCpuLoad.currentLoad.toPrecision(3)),
+              // overall used memory percentage (excluding buffer)
+              memory: Number((systemMemInfo.active * 100 / systemMemInfo.total)
+                  .toPrecision(3))
+            }
+          });
+        } else {
+          // For other packages, we use pidusage-tree to include subprocesses
+          const stats = await pidusageTree(pid);
+
+          const nonNullStats = _.filter(stats, stat => stat !== null && stat !== undefined);
+
+          pkgData.samples.push({
+            cpu: Number(
+              _.reduce(nonNullStats, (sum, stat) => sum + (stat ? stat.cpu : 0), 0)
+                .toPrecision(3)
+            ), // CPU usage percentage (aggregated)
+            // memory: _.reduce(nonNullStats, (sum, stat) => sum + (stat ? stat.memory : 0), 0), // Memory usage in bytes (aggregated)
+          });
+        }
+      } catch (err) {
+        log.warn(`Failed to get resource usage for ${pkgName} (PID: ${pid}):`);
+        return;
+      }
+    }));
+
+    // If first package has enough samples, publish all
+    const firstPkg = Object.keys(this.monitoredPackages)[0];
+
+    if (this.initialized) {
+      if (this.monitoredPackages[firstPkg]?.samples.length >= SAMPLES_PER_BATCH) {
+
+        const dataToSend = {
+          timestamps: this.sampleTimestamps.slice(-SAMPLES_PER_BATCH),
+          samplesPerPackage: {}
+        };
+
+        _.forEach(this.monitoredPackages, (pkgData, pkgName) => {
+
+          pkgData.samples = pkgData.samples.slice(-SAMPLES_PER_BATCH);
+          // complete samples with 0 on the left side if needed
+          while (pkgData.samples.length < SAMPLES_PER_BATCH) {
+            pkgData.samples.unshift({
+              cpu: 0,
+              // memory: 0,
+              system: pkgName === 'robot-agent' ? { cpu: 0, memory: 0 } : undefined
+            });
+          }
+
+          // Convert to new schema format: separate arrays for cpu and memory
+          const cpuSamples = pkgData.samples.map(sample => sample.cpu);
+          const memorySamples = pkgData.samples.map(sample => sample.memory);
+
+          dataToSend.samplesPerPackage[pkgName] = {
+            cpu: cpuSamples,
+            // memory: memorySamples
+          };
+
+          // Add system metrics for robot-agent
+          if (pkgName === 'robot-agent') {
+            dataToSend.samplesPerPackage[pkgName].system = {
+              cpu: pkgData.samples.map(sample => sample.system?.cpu || 0),
+              memory: pkgData.samples.map(sample => sample.system?.memory || 0)
+            };
+          }
+        });
+
+        this.mqttSync.data.update(this.metricsTopic, dataToSend);
+
+        // Clear samples after publishing
+        _.forEach(this.monitoredPackages, pkgData => { pkgData.samples = []; });
+      }
+    }
+  }
+
+  /** Add the named package and pi to the list of packages to monitor resource
+  * of. */
   startMonitoring(packageName, pid) {
     if (!this.monitoredPackages[packageName]) {
       log.info(`Starting resource monitoring for ${packageName} (PID: ${pid})`);
@@ -135,6 +148,7 @@ class ResourceMonitor {
     }
   }
 
+  /** Remove package from the list of packages to monitor. */
   stopMonitoring(packageName) {
     if (this.monitoredPackages[packageName]) {
       delete this.monitoredPackages[packageName];

--- a/robot-agent/start_agent.sh
+++ b/robot-agent/start_agent.sh
@@ -24,7 +24,7 @@ while (true); do
   ./generate_certs.sh
 
   cd $DIR/node_modules/@transitive-robotics/robot-agent
-  $NPM start 2>&1 | tee -a $DIR/agent.log;
+  $NPM start;
   sleep 2;
   echo "Restarting the agent"
 done

--- a/robot-agent/utils.js
+++ b/robot-agent/utils.js
@@ -368,6 +368,12 @@ const upgradeNodejs = (cb) => {
   });
 }
 
+/** Round to precision avoiding the string conversions of Number(x.toPrecision()).
+*/
+const toPrecision = (number, precision) => {
+  const factor = Math.pow(10, precision);
+  return Math.trunc(number * factor) / factor;
+};
 
 module.exports = {
   restartPackage,
@@ -382,4 +388,5 @@ module.exports = {
   watchStatus,
   getInstalledPackages,
   getPackagePid,
+  toPrecision
 };

--- a/robot-agent/utils.js
+++ b/robot-agent/utils.js
@@ -262,13 +262,13 @@ const logRotate = (file, count = LOG_COUNT) => {
 const rotateAllLogs = () => {
   const agentLogFile = `${constants.TRANSITIVE_DIR}/agent.log`;
   logRotate(agentLogFile);
-  LogMonitor.clearErrors('robot-agent');
+  logMonitor.clearErrors('robot-agent');
 
   const list = getInstalledPackages();
   list.forEach(dir => {
     const logFile = `${basePath}/${dir}/log`;
     logRotate(logFile);
-    LogMonitor.clearErrors(dir);
+    logMonitor.clearErrors(dir);
   });
 };
 

--- a/robot-agent/utils.js
+++ b/robot-agent/utils.js
@@ -40,7 +40,7 @@ const getInstalledPackages = () => {
 
 /**
  * Gets the process ID (PID) of a running package
- * 
+ *
  * @param {string} pkgName - The name of the package to find the PID for
  */
 const getPackagePid = (pkgName) =>{
@@ -55,7 +55,7 @@ const getPackagePid = (pkgName) =>{
         pkgPid = pid;
       } else {
         log.warn(`pgrep did not return a valid PID for package ${pkgName}`);
-      }      
+      }
     });
 
     pgrep.stdout.on('end', () => {
@@ -244,7 +244,7 @@ const fileExists = (filePath) => {
 }
 
 /** rotate given (log) file */
-const logRotate = (file, {count}) => {
+const logRotate = (file, count = LOG_COUNT) => {
   if (!fileExists(file)) return;
 
   for (let i = count - 1; i > 0; i--) {
@@ -261,16 +261,14 @@ const logRotate = (file, {count}) => {
 /** rotate the log files for all installed packages */
 const rotateAllLogs = () => {
   const agentLogFile = `${constants.TRANSITIVE_DIR}/agent.log`;
-  logRotate(agentLogFile, {count: LOG_COUNT}, (err) =>
-    err && log.error('error rotating agent log file', err));
-  logMonitor.clearErrorCount('robot-agent')
+  logRotate(agentLogFile);
+  LogMonitor.clearErrors('robot-agent');
+
   const list = getInstalledPackages();
   list.forEach(dir => {
     const logFile = `${basePath}/${dir}/log`;
-    logRotate(logFile, {count: LOG_COUNT}, (err) =>
-      err && log.error(`error rotating log file for ${dir}`, err)
-    );
-    logMonitor.clearErrorCount(dir);
+    logRotate(logFile);
+    LogMonitor.clearErrors(dir);
   });
 };
 

--- a/robot-agent/utils.test.js
+++ b/robot-agent/utils.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { getInstalledPackages } = require('./utils');
+const { getInstalledPackages, toPrecision } = require('./utils');
 
 describe('utils', function() {
   // currently only used for its output (manually inspected test)
@@ -7,4 +7,16 @@ describe('utils', function() {
     const list = getInstalledPackages();
     console.log(list);
   });
+
+  describe('toPrecision', function() {
+    it('should be correct', function() {
+      assert.equal( toPrecision(3.1234, 0), 3);
+      assert.equal( toPrecision(3.1234, 1), 3.1);
+      assert.equal( toPrecision(3.1234, 2), 3.12);
+      assert.equal( toPrecision(3.1234, 6), 3.1234);
+
+      assert.equal( toPrecision(312.34, -1), 310);
+    });
+  });
+
 });


### PR DESCRIPTION
[Small changes to docker-compose.yaml (ports) and sample.env](https://github.com/transitiverobotics/transitive/commit/b9ea483894bf69c231a18a2e916bf25b30b3b0df)

[agent logMonitor: simplified start-processing logic](https://github.com/transitiverobotics/transitive/commit/7490a7f3414f4b785f9912886bc074e71249f19e) 
 - also: tidied up `utils.logRotate` a bit

[log ingest: now zipping pending logs for upload](https://github.com/transitiverobotics/transitive/commit/fa67c4340199cfbcabc7ab585bef5e2983650c93) 
  - accordingly unzipping in server and live-tailing in robot-agent-device

[agent: simplified resource monitor](https://github.com/transitiverobotics/transitive/commit/30a8d518987eb340ffa3d134b49ef72ed7353ec5) 

- fixed an async bug in collection
- broke down the code a bit more
- removed process mem
- made memory be a percentage of total
- switched to "active" memory -- used memory is a misleading number
- made sure logs are not uploaded more than every 10s in normal operation (batching is fine)

[agent device: styling the sparklines a bit more, simplify code](https://github.com/transitiverobotics/transitive/commit/480b1d059809b67de6750e786a3ecbaeded88cd7)

[further simplified resource monitoring and display](https://github.com/transitiverobotics/transitive/commit/1b06a2ebf7a85faef049044eab74a9093493ac15)

[simplifying log monitoring and related code](https://github.com/transitiverobotics/transitive/commit/51556eab904c188ae3ffd59f722260383c24ddc8) 

- simplified logic overall (removed some now unnecessary try's and if's and unused class fields)
- moved rotateAllLogs to after logMonitor init
- lastLogTimestamp is now written by cloud, not robot (was previously lost due to initial clearing by agent)
- check already running packages when monitors start to watch those as well
- converted all log levels to lower case like we do elsewhere
- debouncing config updates since file-watching causes multiple events per file-change
- log monitoring: count errors server-side, send resets from robot
- when rotating logs, robots indicate a "reset", which will trigger the server to set error counts to zero for all packages on that device
- avoids an issue we saw with pre-existing errors causing a lot of error-updates in mqttsync
- simplified get-log-button-with-errors
- log ingest: made robot-agent more like a normal package
  - also reduces difference between dev and prod (same log file, same npm start script)
- enforcing ansi colors in logs, using ansi in log display; trigger rotateLogs from logMonitor

[updated metrics ingest code for new format](https://github.com/transitiverobotics/transitive/commit/c1ab593c8db75c56ea5338ddf2a06df3b3d296d0)

