### PR TITLE
robot-agent@2.5.1: no FORCE_COLOR during `npm install`

### DIFF
--- a/robot-agent/package-lock.json
+++ b/robot-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@transitive-robotics/robot-agent",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@transitive-robotics/robot-agent",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/robot-agent/package.json
+++ b/robot-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitive-robotics/robot-agent",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "The Transitive Robotics robot agent, responsible for installing and starting capability packages on the device and relaying mqtt communication.",
   "main": "index.js",
   "scripts": {

--- a/robot-agent/startPackage.sh
+++ b/robot-agent/startPackage.sh
@@ -115,16 +115,17 @@ do
       echo "Config file $CONFIG_FILE is empty"
       export TRCONFIG="{}"
     fi
-  else    
+  else
     echo "Config file $CONFIG_FILE not found"
-     export TRCONFIG="{}"
+    export TRCONFIG="{}"
   fi
-  
+
   echo "TRCONFIG: $TRCONFIG"
 
   cd "$BASE/node_modules/$1"
   export PASSWORD=$(cat ../../../password)
-  npm start &
+  # setting FORCE_COLOR=1 to force ANSI colors in Chalk (for logging)
+  FORCE_COLOR=1 npm start &
   echo '{"status": "started"}' > $STATUS_FILE
   pid=$!
   echo "node process pid: $pid"

--- a/robot-agent/utils.js
+++ b/robot-agent/utils.js
@@ -171,7 +171,6 @@ const startPackage = (name) => {
             {
               TRPACKAGE: name,
               TR_ROS_RELEASES: config?.global?.rosReleases?.join(' '),
-              FORCE_COLOR: 1 // force chalk level 1 (color logging)
             })
         });
       subprocess.unref();


### PR DESCRIPTION
`npm i rclnodejs` fails when using `FORCE_COLOR=1`; now only setting that on `npm start` inside `startPackage.sh`

Fixes #issues/628.