### PR TITLE
robot-agent: new config option: `aggressiveReconnect`

### DIFF
--- a/robot-agent/package-lock.json
+++ b/robot-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@transitive-robotics/robot-agent",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@transitive-robotics/robot-agent",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/robot-agent/package.json
+++ b/robot-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitive-robotics/robot-agent",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "The Transitive Robotics robot agent, responsible for installing and starting capability packages on the device and relaying mqtt communication.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- when set to `true`, it will aggressively (force-)end the mqtt connection and reconnect whenever no $SYS heartbeat has been received for more than a threshold (currently 65 seconds). While this should not be necessary, it appears there are some network configurations where it is (where the agent would otherwise not reconnect after a network outage).