### PR TITLE
robot-agent: narrowing update and avoiding error

### DIFF
--- a/robot-agent/package-lock.json
+++ b/robot-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@transitive-robotics/robot-agent",
-  "version": "2.5.5",
+  "version": "2.5.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@transitive-robotics/robot-agent",
-      "version": "2.5.5",
+      "version": "2.5.8",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/robot-agent/package.json
+++ b/robot-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitive-robotics/robot-agent",
-  "version": "2.5.5",
+  "version": "2.5.8",
   "description": "The Transitive Robotics robot agent, responsible for installing and starting capability packages on the device and relaying mqtt communication.",
   "main": "index.js",
   "scripts": {

--- a/robot-agent/start_agent.sh
+++ b/robot-agent/start_agent.sh
@@ -6,6 +6,9 @@ NPM="$NODE $DIR/usr/bin/npm"
 
 export PATH=$DIR/usr/sbin:$DIR/usr/bin:$DIR/sbin:$DIR/bin:$PATH
 
+# get and save version of ourselves (this script)
+VERSION=$((cd node_modules/@transitive-robotics/robot-agent/ && $NPM pkg get version) || echo '0')
+
 # for n in $(cat $DIR/.env | grep -v "^#"); do export $n; done
 # if [[ -f $DIR/.env_user ]]; then
 #   for n in $(cat $DIR/.env_user | grep -v "^#"); do export $n; done
@@ -14,12 +17,17 @@ export PATH=$DIR/usr/sbin:$DIR/usr/bin:$DIR/sbin:$DIR/bin:$PATH
 # export PATH=$PATH:$DIR/usr/sbin:$DIR/usr/bin:$DIR/sbin:$DIR/bin
 # export NO_SYSTEMD=1
 while (true); do
+  # Print running version of _this_ script (for debugging). This does NOT update
+  # until a restart of the systemd service or the container.
+  echo "$0 v$VERSION (loop start)"
+
   cd $DIR
   # The `rm` here is to clear out old npm folders from a potentially failed
   # update (or whatever else leaves these beind, see
   # https://docs.npmjs.com/common-errors#many-enoent--enotempty-errors-in-output.
-  rm -rf node_modules/.*-* node_modules/@*/.*-*
-  $NPM update --no-save
+  # rm -rf node_modules/.*-* node_modules/@*/.*-*
+  rm -rf node_modules/.*-* node_modules/@*/.*-* node_modules/*/node_modules/.*-*
+  $NPM update --no-save @transitive-robotics/robot-agent
 
   ./generate_certs.sh
 


### PR DESCRIPTION
- makes the `npm update` check faster by only checking for updates to the agent itself (not all its dependencies)
- avoids errors/warnings such as this one by removing such conflicting folders:
```
Restarting the agent
npm ERR! code ENOTEMPTY
npm ERR! syscall rename
npm ERR! path /root/.transitive/node_modules/bl/node_modules/readable-stream
npm ERR! dest /root/.transitive/node_modules/bl/node_modules/.readable-stream-JiT39NSa
npm ERR! errno -39
npm ERR! ENOTEMPTY: directory not empty, rename '/root/.transitive/node_modules/bl/node_modules/readable-stream' -> '/root/.transitive/node_modules/bl/node_modules/.readable-stream-JiT39NSa'
npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2026-04-23T16_55_02_134Z-debug-0.log
```