### PR TITLE
Portal: increase mem limit for cloud caps to 1GB

### DIFF
--- a/cloud/app/package-lock.json
+++ b/cloud/app/package-lock.json
@@ -32,7 +32,6 @@
         "jsonwebtoken": "^9.0.3",
         "lodash": "^4.17.21",
         "node-fetch": "^2.6.7",
-        "pako": "^2.0.4",
         "prism-react-renderer": "^2.0.5",
         "prompt": "^1.2.1",
         "react": "^18.3.1",
@@ -7638,12 +7637,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",

--- a/cloud/app/package.json
+++ b/cloud/app/package.json
@@ -27,7 +27,6 @@
     "jsonwebtoken": "^9.0.3",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",
-    "pako": "^2.0.4",
     "prism-react-renderer": "^2.0.5",
     "prompt": "^1.2.1",
     "react": "^18.3.1",

--- a/cloud/app/server/docker.js
+++ b/cloud/app/server/docker.js
@@ -133,8 +133,8 @@ const build = async ({name, version, pkgInfo}) => {
   const externalIp = await dns.promises.lookup(process.env.TR_HOST, {family: 4});
   log.debug({externalIp});
   fs.writeFileSync(path.join(dir, 'Dockerfile'), [
-      'FROM node:20.12.2',
-      // 'FROM node:20.20.2', // 20.19.3+ required by mongodb@7
+      // 'FROM node:20.12.2',
+      'FROM node:20.20.2', // 20.19.3+ required by mongodb@7
       'RUN apt-get update',
       'COPY . /app/',
       'WORKDIR /app',
@@ -142,10 +142,6 @@ const build = async ({name, version, pkgInfo}) => {
       `ENV TR_HOST=${process.env.TR_HOST}`,
       `ENV EXTERNAL_IP=${externalIp.address}`,
       'ENV TRANSITIVE_IS_CLOUD=1',
-      // Required in order to install indirect dependencies from the
-      // @transitive-robotics scope
-      // #TODO: No longer used, remove
-      'ENV npm_config_userconfig=/app/.npmrc',
       'RUN npm install',
       // TODO: remove the next line once all caps use utils@0.7.1, i.e., they
       // find certs in upper folders if needed
@@ -211,7 +207,8 @@ const start = async ({name, version, pkgInfo}) => {
     NetworkMode: 'cloud_caps',
     Init: true, // start an init process that reaps zombies, e.g., sshd's
     LogConfig: { Type: 'local' },
-    Memory: 500 * Math.pow(2,20), // 500MB memory limit
+    // memory limit; can peak over 500 MB during `npm update`; see #686
+    Memory: 1000 * Math.pow(2,20),
   };
 
   let ExposedPorts;

--- a/cloud/app/web_components/shared.jsx
+++ b/cloud/app/web_components/shared.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useReducer, useState } from 'react';
-import pako from 'pako';
 
 import { Modal, Badge, OverlayTrigger, Tooltip, Button } from 'react-bootstrap';
 import { FaCircle, FaRegCircle } from 'react-icons/fa';
@@ -70,11 +69,20 @@ export const ensureProps = (props, list) => list.every(name => {
 });
 
 
+/** given an array of bytes or string, decompress and return result */
+const decompress = async (bytes) => {
+  const stream = new DecompressionStream('gzip');
+  const writer = stream.writable.getWriter();
+  writer.write(bytes);
+  writer.close();
+  return new Response(stream.readable).text();
+}
+
 /** given a compressed base64 buffer, convert and decompress */
-const decompress = (zippedBase64) => {
-  const buf = Uint8Array.from(atob(zippedBase64), c => c.charCodeAt(0));
-  return pako.ungzip(buf, {to: 'string'});
-};
+const decompressBase64 = async (zippedBase64) => {
+  const bytes = Uint8Array.from(atob(zippedBase64), c => c.charCodeAt(0));
+  return decompress(bytes);
+}
 
 /** Component that renders the package log response, such as
 {
@@ -94,7 +102,6 @@ export const PkgLog = ({response, mqttClient, agentPrefix, hide}) => {
   const cap = Object.values(response)[0];
   const capName = Object.keys(cap)[0];
   const result = Object.values(cap)[0];
-  const stdout = decompress(result.stdout);
 
   // const packageName = (capName === 'robot-agent') ?
   //   'robot-agent' : `${scope}/${capName}`;
@@ -125,10 +132,9 @@ export const PkgLog = ({response, mqttClient, agentPrefix, hide}) => {
           }
         });
 
-        mqttClient.on('message', (msgTopic, message) => {
+        mqttClient.on('message', async (msgTopic, message) => {
           if (msgTopic === topic) {
-            // const logLines = message && JSON.parse(message.toString());
-            const jsonStr = pako.ungzip(message, {to: 'string'});
+            const jsonStr = await decompress(message);
             const logLines = message && JSON.parse(jsonStr);
 
             if (!logLines || !Array.isArray(logLines) || logLines.length === 0) {
@@ -153,10 +159,17 @@ export const PkgLog = ({response, mqttClient, agentPrefix, hide}) => {
       }
     }, [mqttClient, scope, capName]);
 
+  const [lines, setLines] = useState(null);
 
-  const lines = stdout ? stdout.split(/\n/g) : null;
+  // decompress the result we got, set the lines from it
+  useEffect(() => {
+      const run = async () => {
+        const stdout = await decompressBase64(result.stdout);
+        setLines(stdout ? stdout.split(/\n/g) : []);
+      }
+      run();
+    }, []);
 
-  // fullscreen={true}
   return <Modal show={true} size='xl' onHide={hide} >
     <Modal.Header closeButton>
       <Modal.Title>Log for {packageName}</Modal.Title>
@@ -165,15 +178,16 @@ export const PkgLog = ({response, mqttClient, agentPrefix, hide}) => {
       background: 'hsl(240, 7%, 5%)',
       color: '#eee',
     }}>
-      {/* {stdout ? <pre style={style}>{stdout}</pre> : <div>stdout is empty</div>} */}
       { lines ?
-        lines.map((line, i) => <AnsiHtml style={style} text={line} key={i}/>)
-        : <div>stdout is empty</div>
+        ( lines.length > 0 ?
+          lines.map((line, i) => <AnsiHtml style={style} text={line} key={i}/>)
+          : <div>stdout is empty</div>
+        )
+        : <div>fetching log...</div>
       }
-
       <hr/>
-      <h6>Live Log, configured <tt>minLogLevel</tt> and above only (default: "error"):</h6>
 
+      <h6>Live Log, configured <tt>minLogLevel</tt> and above only (default: "error"):</h6>
       <pre style={style}>
         {liveLogs}
       </pre>

--- a/cloud/app/web_components/shared.jsx
+++ b/cloud/app/web_components/shared.jsx
@@ -207,7 +207,10 @@ export const LogButtonWithCounter = (props) => {
     const topic = `${versionPrefix}/rpc/getPkgLog`;
     log.debug('running getPkgLog command', {topic, pkg: packageName});
 
-    mqttSync.call(topic, {pkg: packageName}, (response) => {
+    const lines = Number(window.tr_logLines || 10000);
+    log.info(`To get more/less than 10000 log lines, set window.tr_logLines`);
+
+    mqttSync.call(topic, {pkg: packageName, lines}, (response) => {
       log.debug('got package log response', response);
       const [scope, capName] = packageName.split('/');
       setPkgLog({[scope]: {[capName]: response}});

--- a/robot-agent/commands.js
+++ b/robot-agent/commands.js
@@ -44,9 +44,13 @@ const commands = {
     killPackage(pkg);
   },
 
-  getPkgLog: ({pkg}) => {
+  getPkgLog: ({pkg, lines = 10000}) => {
     return new Promise((resolve, reject) => {
-      exec(`cat ~/.transitive/packages/${pkg}/log | tail -n 100000`,
+      exec(`cat log.3 log.2 log.1 log | tail -n ${lines}`,
+        {
+          maxBuffer: 100 * 1024 * 1024,
+          cwd: `${process.env.HOME}/.transitive/packages/${pkg}`
+        },
         (err, stdout, stderr) => resolve({
           err,
           stdout: zlib.gzipSync(stdout).toString('base64'),

--- a/robot-agent/package-lock.json
+++ b/robot-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@transitive-robotics/robot-agent",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@transitive-robotics/robot-agent",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/robot-agent/package.json
+++ b/robot-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitive-robotics/robot-agent",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "The Transitive Robotics robot agent, responsible for installing and starting capability packages on the device and relaying mqtt communication.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- `npm update` can use close to 500 MB already, so with the capability running we go over that limit easily, causing the update to fail (OOM killed).
- also upgrades cloud cap nodejs version to 20.20.2

Fixes #686.

Also fixes robot-agent package log truncation and includes old logs in `tail`.

